### PR TITLE
Difxcalc comparison

### DIFF
--- a/pycalc11/calcfile.py
+++ b/pycalc11/calcfile.py
@@ -97,11 +97,11 @@ def make_calc(station_coords, station_names, source_coords,
     lines.append("NUM EOPS: {:d}".format(len(times)))
     for ti in range(len(times)):
         newlines = [
-            "EOP {:d} TIME (mjd):   {:.0f}".format(ti, mjd[ti]),
+            "EOP {:d} TIME (mjd):{:.0f}".format(ti, mjd[ti]),
             "EOP {:d} TAI_UTC (sec):{:.0f}".format(ti, tai_utc[ti]),
-            "EOP {:d} UT1_UTC (sec): {:.10f}".format(ti, ut1_utc[ti]),
-            "EOP {:d} XPOLE (arcsec): {:.10f}".format(ti, xy[ti][0]),
-            "EOP {:d} YPOLE (arcsec): {:.10f}".format(ti, xy[ti][1]),
+            "EOP {:d} UT1_UTC (sec):{:.8f}".format(ti, ut1_utc[ti]),
+            "EOP {:d} XPOLE (arcsec):{:.10f}".format(ti, xy[ti][0]),
+            "EOP {:d} YPOLE (arcsec):{:.10f}".format(ti, xy[ti][1]),
         ]
         lines.extend(newlines)
 
@@ -114,8 +114,8 @@ def make_calc(station_coords, station_names, source_coords,
     for si, (coord, name) in enumerate(zip(source_coords, source_names)):
         newlines = [
             "SOURCE {:d} NAME:      {}".format(si, name),
-            "SOURCE {:d} RA:        {:.8f}".format(si, coord.ra.rad),      # radians
-            "SOURCE {:d} DEC:       {:.8f}".format(si, coord.dec.rad),      # radians
+            "SOURCE {:d} RA:        {:.10f}".format(si, coord.ra.rad),      # radians
+            "SOURCE {:d} DEC:       {:.10f}".format(si, coord.dec.rad),      # radians
             "SOURCE {:d} CALCODE:   B".format(si),
             "SOURCE {:d} QUAL:      0".format(si),
         ]

--- a/pycalc11/imfile.py
+++ b/pycalc11/imfile.py
@@ -1,0 +1,235 @@
+#!/bin/env python
+"""
+Module to parse difxcalc output files (.im).
+"""
+
+import numpy as np
+from datetime import datetime
+from astropy.time import Time, TimeDelta
+
+
+class TimeRange:
+    """
+    Helper class to quickly represent a range of times.
+
+    Parameters
+    ----------
+    start: astropy.time.Time
+        Start time
+    end: astropy.time.Time
+        End time
+    """
+
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+    def __contains__(self, other):
+        """
+        Check if start <= other <= end
+
+        Parameters
+        ----------
+        other: astropy.time.Time
+            Time to check.
+        """
+        return (
+            (other.mjd > self.start.mjd or np.isclose(other.mjd, self.start.mjd, atol=1e-6, rtol=0.0)) and
+            (other.mjd <= self.end.mjd or np.isclose(other.mjd, self.end.mjd, atol=1e-6, rtol=0.0))
+        )
+
+    def __repr__(self):
+        """String representation."""
+        return "{} -- {}".format(self.start.isot, self.end.isot)
+
+
+class CalcReader:
+    """
+    Reads difxcalc output .im files and evaluates polynomials for delay.
+
+    Parameters
+    ----------
+    filename: str
+        Path to file to load. Optional.
+    """
+
+    poly_order = None
+    interval = None
+    antnames = None
+    antnums = None
+    num_scans = None
+    params = None
+    filename = None
+
+    def __init__(self, filename=None):
+        if filename is not None:
+            self.read_im(filename)
+
+
+    def read_im(self, filename):
+        """
+        Read in .im file.
+
+        Parameters
+        ----------
+        filename: str
+            Path to file to load. Optional.
+        """
+        self.filename = filename
+        lines = open(filename, 'r').readlines()
+
+        # Form a dictionary of data in the file.
+        # This needs to be done line by line, because some line prefixes are the same,
+        # and their meaning changes based on the order in the file.
+        dat_dict = {}
+
+        cur_scan = -1
+        cur_poly = -1
+        for line in lines:
+
+            pref, dat = line.split(':')
+            dat = dat.rstrip()
+            pref = pref.replace(' ', '_')
+
+            try:
+                dat = int(dat)
+            except ValueError:
+                try:
+                    dat = float(dat)
+                except ValueError:
+                    dat = dat.strip()
+                    pass
+
+            if pref.startswith("SCAN"):
+                spl = pref.split('_')
+                cur_scan = int(spl[1])
+                cur_poly = -1   # reset
+
+                if spl[2] == 'POLY':
+                    cur_poly = int(spl[3])
+
+            if cur_poly > -1 and not pref.startswith("SCAN"):
+                pref = f"POLY_{cur_poly}_" + pref
+
+            if cur_scan > -1 and not pref.startswith("SCAN"):
+                pref = f"SCAN_{cur_scan}_" + pref
+
+            if any(
+                key in pref
+                for key in ['DELAY', 'DRY', 'WET', 'AZ', 'EL_GEOM', 'U_(m)', 'V_(m)', 'W_(m)']
+            ):
+                lst = np.array(dat.split()).astype(float)
+                dat = np.poly1d(lst[::-1])
+
+            dat_dict[pref] = dat
+
+            self.params = dat_dict
+
+        # Create a dictionary identifying valid time ranges for each set of polynomials.
+        self.poly_ranges = {}
+        for scan_i in range(self.params['NUM_SCANS']):
+            npoly = self.params[f"SCAN_{scan_i}_NUM_POLY"]
+            for pol_i in range(npoly):
+                key = (scan_i, pol_i)
+                ti = Time(
+                        self.params[f"SCAN_{scan_i}_POLY_{pol_i}_MJD"]
+                        + self.params[f"SCAN_{scan_i}_POLY_{pol_i}_SEC"] / (24 * 3600),
+                format='mjd')
+                tf = ti + TimeDelta(self.params['INTERVAL_(SECS)'], format='sec')
+
+                self.poly_ranges[key] = TimeRange(ti, tf)
+
+        # Collect the start time from other keywords.
+        start_date = datetime(
+            self.params['START_YEAR'],
+            self.params['START_MONTH'],
+            self.params['START_DAY'],
+            self.params['START_HOUR'],
+            self.params['START_MINUTE'],
+            self.params['START_SECOND'],
+        )
+        self.start_date = Time(start_date, format='datetime')
+
+        # Get the telescope names and numbers:
+        n_ants = self.params['NUM_TELESCOPES']
+        self.antnames = [None] * n_ants
+        self.antnums = list(range(n_ants))
+        for ai in range(n_ants):
+            self.antnames[ai] = self.params[f"TELESCOPE_{ai}_NAME"]
+
+    def _get_polykey(self, time, ant_num, src_num, scan):
+        # Find polynomial for time/ant/scan.
+        polyind = None
+        for pi, ran in self.poly_ranges.items():
+            if (time in ran) and (pi[0] == scan):
+                polyind = pi
+                break
+        if polyind is None:
+            raise ValueError(f"Time {time} is not covered by current polynomials for scan {scan}.")
+
+        pscan, pnum = polyind
+        key = f"SCAN_{pscan}_POLY_{pnum}_SRC_{src_num}_ANT_{ant_num}"
+
+        return polyind, key
+
+    def delay(self, ant_num, time, src_num, scan=0):
+        """
+        Geocentric delay in microseconds.
+
+        Parameters
+        ----------
+        ant_num: int
+            Index of antenna.
+        time: astropy.time.Time
+            Time of observation.
+        src_num: int
+            Source number.
+        scan: int
+            Scan index number (default 0)
+
+        Returns
+        -------
+        float
+            Delay in microseconds.
+        """
+        if self.poly_ranges is None:
+            raise ValueError("Need to read a file first.")
+
+        polyind, key = self._get_polykey(time, ant_num, src_num, scan)
+        poly = self.params[key + "_DELAY_(us)"]
+        polystart = self.poly_ranges[polyind].start
+        # Evaluate polynomial:
+        dt = (time - polystart).sec
+        delay = np.polyval(poly, dt)
+
+        return delay
+
+    def baseline_delay(self, ant1, ant2, time, src_num, scan=0):
+        """
+        Relative delay between two antennas, in microseconds.
+
+        Returns light travel time from ant1 to ant2.
+
+        Parameters
+        ----------
+        ant1: int
+            Index of antenna 1.
+        ant2: int
+            Index of antenna 2
+        time: astropy.time.Time
+            Time of observation.
+        src_num: int
+            Source number.
+        scan: int
+            Scan index number (default 0)
+
+        Returns
+        -------
+        float
+            Delay in microseconds.
+        """
+        return (
+            self.delay(ant2, time, src_num, scan=scan)
+            - self.delay(ant1, time, src_num, scan=scan)
+        )
+


### PR DESCRIPTION
Fixes a test verifying agreement between difxcalc and pycalc to sub-picosecond precision. It turns out that the test relied on a file that wasn't being tracked by git, which defined a ".im" file reader (like difxcalc-wrapper). There was a small bug in how it picked which polynomial fit to use, causing it to default to the zeroth solution (i.e., the first 2-minute window). Hence, results diverged on timescales longer than 2 minutes.

I also checked some intermediate variables in calc for consistency with difxcalc, and fixed these by setting correct precisions in the calcfile writer.