### PR TITLE
use 4-byte integer for numstr

### DIFF
--- a/calc11/src/data_module.f
+++ b/calc11/src/data_module.f
@@ -33,10 +33,11 @@
       Real*8     CD, CRA, SD, SRA
       CHARACTER(len=20), allocatable, dimension(:) :: SrcName
       Integer*4  Pmotion, Dpsec
+      Integer(4) NUMSTR
       Integer*2, allocatable, dimension(:, :) :: LNSTAR
       Integer*4, allocatable, dimension(:) :: PhCntr
 
-      Integer*2  NUMSTR, i1dum
+      Integer*2 i1dum
 
       end module srcmod
 

--- a/calc11/src/dinit.f
+++ b/calc11/src/dinit.f
@@ -190,7 +190,7 @@
       SUBROUTINE alloc_source_arrays(Nsrc)
       use srcmod
       IMPLICIT None
-      Integer*2 Nsrc
+      integer*4, intent(in) :: Nsrc
 
       NumStr = Nsrc
 
@@ -225,7 +225,7 @@
       ! This subroutine needs to be run after allocating LNSTAR
       ! TODO -- Still not working right
 
-      integer*2, intent(in) :: Nsrc
+      integer*4, intent(in) :: Nsrc
       integer*2 ii, jj, val
       character(2) buckets(10)
       character(30) recv


### PR DESCRIPTION
Previously the number of sources was limited to 65536 due to NUMSTR being a 2-byte integer.