### PR TITLE
Reset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,9 @@ find_package(PythonExtensions REQUIRED)
 find_package(NumPy)
 find_package(F2PY REQUIRED)
 
-#set(DATADIR "")
-#set(DE421_FILE "")
-
 # Generate param11.in file in cmake build directory
 file(READ ${CMAKE_SOURCE_DIR}/calc11/src/param11.i.in CONTENTS)
-#string(REPLACE "@prefix@/share/difxcalc" "${DATADIR}" CONTENTS ${CONTENTS})
-#string(REPLACE "@de421_file@" "${DATADIR}" CONTENTS ${CONTENTS})
 file(WRITE ${CMAKE_SOURCE_DIR}/calc11/src/param11.i ${CONTENTS})
-#file(WRITE ${CMAKE_SOURCE_DIR}/test.in ${CONTENTS})
 
 
 set(f2py_module_name "calc11")

--- a/README.rst
+++ b/README.rst
@@ -59,15 +59,12 @@ instance, and duration as a float representing the length of the scan in minutes
     site_names = ['GBT-VLBA', 'VLA_E9', 'ALMA', 'MWA', 'CHIME']
 
     n_srcs = 500    # Arbitrarily many. Previously limited to 300.
-    srcs = ac.SkyCoord(
+    source_coords = ac.SkyCoord(
         ra=np.random.uniform(0, 360, n_srcs),
         dec=np.random.uniform(-90,90, n_srcs),
         unit='deg',
         frame='icrs',
     )
-
-    source_coords = [s for s in srcs]
-    source_names = [f"src{si}" for si in range(n_srcs)]
 
     # ------------
     # Initialize the Calc object.
@@ -76,7 +73,6 @@ instance, and duration as a float representing the length of the scan in minutes
     ci = Calc(
         station_names=site_names,
         station_coords=site_locs,
-        source_names=source_names,
         source_coords=source_coords,
         time=time,
         duration_min=duration_min,

--- a/calc11/src/adrvr.f
+++ b/calc11/src/adrvr.f
@@ -438,9 +438,9 @@
       DO Itime = 1, Epoch2m                     ! Start of epoch loop
 
 !  Define UTC for this epoch
-        If (Itime .gt. 1) TAG_SEC = TAG_SEC +  d_interval     ! seconds
+       If (Itime .gt. 1) TAG_SEC = TAG_SEC +  d_interval     ! seconds
        IF (TAG_SEC .ge. 59.999999999D0) Call FixEpoch2(JTAG, TAG_SEC)
-        TAGSEC = TAG_SEC
+       TAGSEC = TAG_SEC
 !
 !  Compute the Julian date at 0 hours UTC for the year, month, day.
 !  Use function JDY2K to convert year, month, day to Julian date.

--- a/calc11/src/autils.f
+++ b/calc11/src/autils.f
@@ -405,7 +405,6 @@
         Sou26 = Buf1((IX+5):(IX+30)) 
         Sou26 = ADJUSTL(Sou26)
         SrcName(SrcNum+1) = Sou26(1:20)
-!        write(6,*) "TESTING: ", SrcNum
         ! Encode source names in LNSTAR without EQUIVALENCE
         do j=1, 10
            LNSTAR(j,SrcNum+1) = TRANSFER(Sou26((j-1)*2+1:(j-1)*2+2),    &

--- a/pycalc11/interface.py
+++ b/pycalc11/interface.py
@@ -430,7 +430,6 @@ class Calc:
     @station_names.setter
     def station_names(self, station_names):
         if station_names is None:
-            #calc.calc_input.sites[1:] = b""
             return
         calc.sitcm.numsit = len(station_names) + 1
         tnames = [s.upper() for s in station_names]
@@ -454,7 +453,6 @@ class Calc:
     @station_coords.setter
     def station_coords(self, tpos):
         if tpos is None:
-            #calc.sitcm.sitxyz[()] = 0.0
             return
         calc.sitcm.numsit = len(tpos) + 1
         for ti in range(self.nants):

--- a/pycalc11/interface.py
+++ b/pycalc11/interface.py
@@ -32,11 +32,9 @@ class Calc:
         Names of VLBI stations.
     station_coords: array_like of astropy.coordinates.EarthLocation
         Positions of VLBI stations
-    source_names: array_like of str
-        Names of sources.
     source_coords: array_like of astropy.coordinates.SkyCoord
         Positions of sources in ICRS
-    time: astropy.time.Time
+    start_time: astropy.time.Time
         Start time of scan.
     duration_min: float
         Duration of scan in minutes
@@ -67,9 +65,6 @@ class Calc:
 
     _rerun = True       # Rerun driver before accessing results
 
-    src_names = []      # Once the f2py bug (numpy issue 10027) with character arrays is
-                        # fixed, this will be a property pointing to calc.calc_input.sites.
-
     _delay = None
     _delay_rate = None
     _partials = None
@@ -84,14 +79,13 @@ class Calc:
         require_rerun.__doc__ = func.__doc__
         return require_rerun
 
-    def __init__(self, station_names=None, station_coords=None,
-            source_names=None, source_coords=None,
-            time=None, duration_min=None,
+    def __init__(self, station_names=None, station_coords=None, source_coords=None,
+            start_time=None, duration_min=None,
             base_mode='geocenter', uvw_mode='exact', dry_atm=True, wet_atm=True,
             calc_file=None,
         ):
         # Setting defaults
-        self.reset()
+        self._reset()        # Clear if there's another instance.
         calc.mode.c_mode = 'difx  '
         calc.contrl.near_far = 'Far-field '
         calc.contrl.l_time = 'dont-solve'   # Optionally solve for LTT if using near-field
@@ -109,9 +103,8 @@ class Calc:
 
         # Check for required parameters
         kwargs = {
-                "station_names" : station_names, "station_coords" : station_coords,
-                "source_names": source_names, "source_coords": source_coords,
-                "time" : time, "duration_min" : duration_min, "base_mode" : base_mode,
+                "station_names" : station_names, "station_coords" : station_coords, "source_coords": source_coords,
+                "start_time" : start_time, "duration_min" : duration_min, "base_mode" : base_mode,
         }
 
         # Behavior:
@@ -119,11 +112,6 @@ class Calc:
         #   - If other parameters are provided, they override calc_file settings.
         if calc_file is not None:
             self.calc_file = calc_file
-            nsrcs, nstat = self.parse_calcfile(calc_file)
-            calc.alloc_source_arrays(nsrcs)
-            calc.dget_input(1)
-            calc.sitcm.numsit += 1      # Numsit in calc must include the geocenter.
-            calc.dscan(1,1)
         elif not all(v is not None for k,v in kwargs.items()):
             raise ValueError(
                 "If calc_file is not set, then all of the following must be set:"
@@ -134,22 +122,21 @@ class Calc:
             del self.calc_file
 
         # Initialize stations, sources, scan, and eops
-        if station_names is not None and station_coords is not None:
-            self.set_stations(station_names, station_coords)
-        if source_names is not None and source_coords is not None:
-            self.set_sources(source_names, source_coords)
-        if time is not None:
-            self.set_eops(time)
-            if duration_min is not None:
-                self.set_scan(time, duration_min)
+        self.station_names = station_names
+        self.station_coords = station_coords
+        self.source_coords = source_coords
+        self._start_time = start_time
+        self._duration_min = duration_min
+
+        if start_time is not None:
+            self.set_eops(start_time)
+            self.set_scan(start_time, duration_min)
 
         # Add geocenter station
         self._add_geocenter()
 
-        self.alloc_out_arrays()
-
         # Check ocean loading params are available
-        OceanFiles.check_sites(self.stat_names)
+        OceanFiles.check_sites(self.station_names)
 
         calc.dinitl(1)
 
@@ -174,6 +161,9 @@ class Calc:
 
     def run_driver(self):
         """Run adrivr to get results."""
+        calc.dsiti(1)      # In case stations changed, need to reload ocean loading etc.
+        calc.dwobi()       # Recalc wobble coefs in case EOPs changed.
+        self.alloc_out_arrays()
         e2m = calc.contrl.epoch2m - 1
         for ii in range(calc.calc_input.intrvls2min):
             calc.adrivr(1,ii+1)
@@ -190,27 +180,28 @@ class Calc:
 
         self._rerun = False
 
-    def interpolate_delays(self, t_0): 
-        """ Evaluates the delays at an absolute time t_0 by calculating an akima spline and interpolating delays along the time axis. 
+    def interpolate_delays(self, t_0):
+        """ Evaluates the delays at an absolute time t_0 by calculating an akima spline and interpolating delays along the time axis.
         The inputs to the akima spline is the time in seconds between self.times[0] and the time the delays should be evaluated.
+
         Parameters
         -----------------
         t_0 : astropy.time.Time
             Absolute time at which delays are to be evaluated
+
         Returns
         -----------
-        the delays in seconds evaluated at t_0
+        np.ndarray
+            The delays in seconds evaluated at t_0
         """
-        x=(t_0-self.times[0]).sec 
+        x=(t_0-self.times[0]).sec
         return self.delays_dt(x)
-
-
 
     @property
     def delays_dt(self):
         return Akima1DInterpolator((self.times - self.times[0]).sec, self.delay.to_value('s'), axis=0)
 
-    def reset(self):
+    def _reset(self):
         """Reset all common block items that were not initialized at startup."""
         self._delay = None
         self._delay_rate = None
@@ -241,70 +232,6 @@ class Calc:
         calc.sitcm.sitaxo[0] = 0.0    # Axis offset
         calc.sitcm.sitxyz[:, 0] = [0, 0, 0]
 
-    def set_stations(self, station_names, station_coords):
-        """
-        Set VLBI stations.
-
-        Parameters
-        ----------
-        station_names: list of str
-            Names of stations as strings
-            Should match names in the ocean loading / ocean pole tide loading files
-            if those coefficients are to be included.
-        station_coords: list of astropy.coordinates.EarthLocation
-            Station positions.
-        """
-        calc.sitcm.numsit = len(station_names) + 1
-
-        tnames = [s.upper() for s in station_names]
-        tpos = station_coords
-        for ti in range(self.nants):
-            # Offset of 1 to account for zeroth site being the geocenter
-            calc.calc_input.sites[ti+1] = np.bytes_(tnames[ti].ljust(10))
-            calc.calc_input.axis[ti+1] = "AZEL"
-            calc.sitcm.sitaxo[ti+1] = 0.0    # Axis offset
-            calc.sitcm.sitxyz[0, ti+1] = tpos[ti].x.to_value('m')
-            calc.sitcm.sitxyz[1, ti+1] = tpos[ti].y.to_value('m')
-            calc.sitcm.sitxyz[2, ti+1] = tpos[ti].z.to_value('m')
-        self._rerun = True
-
-    def set_sources(self, source_names, source_coords):
-        """
-        Set sources.
-
-        Parameters
-        ----------
-        source_names: list of str
-            Unique source names
-        source_coords: list of astropy.coordinates.SkyCoord
-            Celestial coordinates (ICRS, GCRS, etc.) of sources.
-        """
-        calc.calc_input.numphcntr = len(source_names)
-        self.src_names = np.asarray(source_names)
-        calc.alloc_source_arrays(self.nsrcs)
-        calc.srcmod.numstr = len(source_names)
-        for si, (coord, name) in enumerate(zip(source_coords, source_names)):
-            calc.srcmod.radec[:, si] = np.round([coord.ra.rad, coord.dec.rad], decimals=10)
-            # calc stores the source names as both a character array and an integer array, using an
-            # EQUIVALENCE to map the memory spaces together (the same bytes are interpreted as integers
-            # in LNSTAR). The following stores the source names correctly in the LNSTAR integer array.
-            calc.srcmod.lnstar[:, si] = np.frombuffer(bytes(name.ljust(20), encoding='utf-8'), dtype=np.int16)
-
-        Nsrc = len(source_names)
-        calc.srcmod.phcntr[:Nsrc] = range(1, Nsrc+1)
-        calc.srcmod.phcntr[Nsrc:] = -1
-
-        # The function call below causes a variety of different errors on shutdown:
-        #   > corrupted_size vs. prev_size
-        #   > segmentation fault
-        #   > double free or corruption (out)
-        #   > (partway through source list) realloc(): invalid old size
-        # calc doesn't actually use source names in difx mode, except in dscan
-        # when handling spacecraft, so this can be set off for now.
-        # Fixing this is a TODO for the future.
-        #calc.set_srcname(Nsrc)
-        self._rerun = True
-
     def set_scan(self, time, duration_min):
         """
         Set start time and duration of scan.
@@ -320,6 +247,7 @@ class Calc:
         """
         jstart = time
         jstop = time + TimeDelta(duration_min * 60, format='sec')
+        calc.con.kctic = 1      # Ensures CT = AT. Shouldn't make a difference, since CT isn't used.
         calc.ut1cm.xintv[0] = jstart.jd
         calc.ut1cm.xintv[1] = jstop.jd
         calc.ut1cm.intrvl[:, 0] = list(jstart.ymdhms)[:5]    # intrvl[:, 1] unused
@@ -331,7 +259,6 @@ class Calc:
         # As defined in dscan.f
         calc.calc_input.intrvls2min = np.ceil(duration_min / 2 + 0.001) + 1     # Number of 2 min intervals
         self._rerun = True
-
 
     def set_eops(self, time):
         """Set Earth orientation parameters.
@@ -438,8 +365,13 @@ class Calc:
         return calc.contrl.calc_file_name[()]
 
     @calc_file.setter
-    def calc_file(self, value):
-        calc.contrl.calc_file_name[()] = value.ljust(128)[:128]
+    def calc_file(self, fname):
+        calc.contrl.calc_file_name[()] = fname.ljust(128)[:128]
+        nsrcs, nstat = self.parse_calcfile(fname)
+        calc.alloc_source_arrays(nsrcs)
+        calc.dget_input(1)
+        calc.sitcm.numsit += 1      # Numsit in calc must include the geocenter.
+        calc.dscan(1,1)
         self._rerun = True
 
     @calc_file.deleter
@@ -457,10 +389,138 @@ class Calc:
         return calc.sitcm.numsit -  1  # Drop geocenter
 
     @property
+    def start_time(self):
+        return self._start_time
+
+    @start_time.setter
+    def start_time(self, time):
+        if time is None:
+            return
+        self._start_time = time
+        self.set_eops(time)
+        self.set_scan(time, self.duration_min)
+        self._rerun = True
+
+    @property
+    def duration_min(self):
+        return self._duration_min
+
+    @duration_min.setter
+    def duration_min(self, dur):
+        if dur is None:
+            return
+        self._duration_min = dur
+        self.set_scan(self._start_time, dur)
+
+    @property
+    def ant1_ind(self):
+        """Index in stations array corresponding with ant1 axis of output arrays."""
+        if self.base_mode == 'geocenter':
+            return 0
+        else:
+            return list(range(self.nants - 1))
+
+    @property
+    def ant2_ind(self):
+        """Index in stations array corresponding with ant2 axis of output arrays."""
+        return list(range(self.nants))
+
+    @property
+    def station_names(self):
+        """Station names."""
+        return calc.calc_input.sites[1:self.nants+1].astype("U8")
+
+    @station_names.setter
+    def station_names(self, station_names):
+        if station_names is None:
+            #calc.calc_input.sites[1:] = b""
+            return
+        calc.sitcm.numsit = len(station_names) + 1
+        tnames = [s.upper() for s in station_names]
+        for ti in range(self.nants):
+            # Offset of 1 to account for zeroth site being the geocenter
+            calc.calc_input.sites[ti+1] = np.bytes_(tnames[ti].ljust(10))
+        self._rerun = True
+
+    @property
+    def station_coords(self):
+        """Station coordinates in ITRF."""
+        return Quantity(
+            calc.sitcm.sitxyz[:, 1:self.nants+1],
+            unit='m',
+            copy=False,
+        )
+
+    @station_coords.setter
+    def station_coords(self, tpos):
+        if tpos is None:
+            #calc.sitcm.sitxyz[()] = 0.0
+            return
+        calc.sitcm.numsit = len(tpos) + 1
+        for ti in range(self.nants):
+            # Offset of 1 to account for zeroth site being the geocenter
+            calc.calc_input.axis[ti+1] = "AZEL"
+            calc.sitcm.sitaxo[ti+1] = 0.0    # Axis offset
+            calc.sitcm.sitxyz[0, ti+1] = tpos[ti].x.to_value('m')
+            calc.sitcm.sitxyz[1, ti+1] = tpos[ti].y.to_value('m')
+            calc.sitcm.sitxyz[2, ti+1] = tpos[ti].z.to_value('m')
+        self._rerun = True
+
+    @property
+    def source_coords(self):
+        """Source coordinates in ICRS ra/dec"""
+        return ac.SkyCoord(
+            ra=calc.srcmod.radec[0],
+            dec=calc.srcmod.radec[1],
+            unit='rad',
+            frame='icrs',
+            copy=False,     # This might not be respected...
+        )
+
+    @source_coords.setter
+    def source_coords(self, src_coords):
+        """Set source positions."""
+#        Nsrc = 0 if not hasattr(src_coords, "__len__") else len(src_coords)
+        if src_coords is None:
+            return
+        Nsrc = len(src_coords)
+        calc.calc_input.numphcntr = Nsrc
+        calc.alloc_source_arrays(self.nsrcs)
+        calc.srcmod.numstr = Nsrc
+        calc.srcmod.radec[0, :] = np.round(src_coords.ra.rad, decimals=10)
+        calc.srcmod.radec[1, :] = np.round(src_coords.dec.rad, decimals=10)
+
+        calc.srcmod.phcntr[:Nsrc] = range(1, Nsrc+1)
+        calc.srcmod.phcntr[Nsrc:] = -1
+        self._rerun = True
+
+    @property
+    def src_ra(self):
+        """Source right ascension in ICRS"""
+        return ac.Longitude(
+            calc.srcmod.radec[0],
+            unit='rad',
+            copy=False,
+        )
+
+    @property
+    def src_dec(self):
+        """Source declination in ICRS"""
+        return ac.Latitude(
+            calc.srcmod.radec[1],
+            unit='rad',
+            copy=False,
+        )
+
+    # ---------------
+    # Results of running the driver
+    # ---------------
+
+    @property
     @_state_dep
     def times(self):
         """List of times for time axis of delay/delay_rate/partials arrays."""
-        return Time(self._times, format='datetime64', scale='utc')
+        return Time(self._times, format='datetime64', scale='utc', copy=False)
 
     @property
     @_state_dep
@@ -510,60 +570,6 @@ class Calc:
         return Quantity(
             vals,
             unit=("s/rad", "s Hz / rad", "s/rad", "s Hz/rad"),
-            copy=False,
-        )
-
-    @property
-    def ant1_ind(self):
-        """Index in stations array corresponding with ant1 axis of output arrays."""
-        if self.base_mode == 'geocenter':
-            return 0
-        else:
-            return list(range(self.nants - 1))
-
-    @property
-    def ant2_ind(self):
-        """Index in stations array corresponding with ant2 axis of output arrays."""
-        return list(range(self.nants))
-
-    @property
-    def stat_names(self):
-        """Station names."""
-        return calc.calc_input.sites[1:self.nants+1].astype("U8")
-
-    @property
-    def stat_coords(self):
-        """Station coordinates in ITRF."""
-        return Quantity(
-            calc.sitcm.sitxyz[:, 1:self.nants+1],
-            unit='m',
-            copy=False,
-        )
-
-    @property
-    def src_coords(self):
-        """Source coordinates in ICRS ra/dec"""
-        return ac.Angle(
-            calc.srcmod.radec,
-            unit='rad',
-            copy=False,
-        )
-
-    @property
-    def src_ra(self):
-        """Source right ascension in ICRS"""
-        return ac.Longitude(
-            calc.srcmod.radec[0],
-            unit='rad',
-            copy=False,
-        )
-
-    @property
-    def src_dec(self):
-        """Source declination in ICRS"""
-        return ac.Latitude(
-            calc.srcmod.radec[1],
-            unit='rad',
             copy=False,
         )
 
@@ -722,7 +728,7 @@ class OceanFiles:
                   + "\n".join(sndists)
                 )
 
-# Init
+# Init an OceanFiles
 OceanFiles()
 
 

--- a/pycalc11/interface.py
+++ b/pycalc11/interface.py
@@ -135,9 +135,6 @@ class Calc:
         # Add geocenter station
         self._add_geocenter()
 
-        # Check ocean loading params are available
-        OceanFiles.check_sites(self.station_names)
-
         calc.dinitl(1)
 
     def parse_calcfile(self, calcfile):
@@ -440,6 +437,9 @@ class Calc:
         for ti in range(self.nants):
             # Offset of 1 to account for zeroth site being the geocenter
             calc.calc_input.sites[ti+1] = np.bytes_(tnames[ti].ljust(10))
+
+        # Check ocean loading params are available
+        OceanFiles.check_sites(self.station_names)
         self._rerun = True
 
     @property

--- a/pycalc11/tests/test_calc.py
+++ b/pycalc11/tests/test_calc.py
@@ -438,22 +438,6 @@ def test_change_quantities(params_vlbi, kv):
         assert ci.delay.shape[-1] == 30
 
 
-def test_compare_baseline_geocenter(params_vlbi):
-    ci = Calc(**params_vlbi)
-    ci.run_driver()
-    delays_geoc = ci.delay.copy()
-    ci.base_mode = "baseline"
-    ci.run_driver()
-    delays_bl = ci.delay.copy()
-    delays_bl_fromgeo = delays_geoc[:, 0, [ci.ant2_ind], :] - delays_geoc[:, 0, ci.ant1_ind, None, :]
-    # delays_bl has zeros for ant2 < ant1
-    for a1, a2 in [(a1, a2) for a1 in ci.ant1_ind for a2 in ci.ant2_ind]:
-        if a2 < a1:
-            delays_bl_fromgeo[:, a1, a2, :] = 0.0
-
-    # !! NOTE Seeing differences on scales of 1 to 12 ns between two methods. Investigate!!
-
-
 ## TODO
 #   Test that epochs cover the requested scan times
 #   Fix tests with astropy comparison

--- a/pycalc11/tests/test_calc.py
+++ b/pycalc11/tests/test_calc.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 from astropy import coordinates as ac
 from astropy.time import Time, TimeDelta
@@ -19,16 +18,15 @@ from pycalc11.imfile import CalcReader
 
 def get_mod_state(fmod):
     odict = {}
-    for k,v in fmod.__dict__.items():
-        if (k.startswith('_')
-                or all([dk.startswith('_') for
-                       dk in v.__dict__])):
+    for k, v in fmod.__dict__.items():
+        if k.startswith("_") or all([dk.startswith("_") for dk in v.__dict__]):
             continue
         for item, value in v.__dict__.items():
             odict[k + "_" + item] = deepcopy(value)
     return odict
 
-def compare_dicts(c0,c1, quiet=False):
+
+def compare_dicts(c0, c1, quiet=False):
     diffs = []
     for k in c1.keys():
         v0 = c0[k]
@@ -46,43 +44,42 @@ def compare_dicts(c0,c1, quiet=False):
             print(diffs)
         return False
 
-#-----------------------------
+
+# -----------------------------
 # Set up station locations and source/scan data
-#-----------------------------
+# -----------------------------
 def make_params(nsrcs=305, duration_min=10):
-    time = Time("2020-10-02T15:30:00.00", format="isot", scale='utc')
+    time = Time("2020-10-02T15:30:00.00", format="isot", scale="utc")
     gbo_loc = ac.EarthLocation.of_site("GBT")
 
-
-    anames = ['gbt', 'vla', 'ALMA', 'mwa', 'chime']
+    anames = ["gbt", "vla", "ALMA", "mwa", "chime"]
     site_locs = [ac.EarthLocation.of_site(nm) for nm in anames]
-    site_names = ['GBT-VLBA', 'VLA_E9', 'ALMA', 'MWA', 'CHIME 0']
+    site_names = ["GBT-VLBA", "VLA_E9", "ALMA", "MWA", "CHIME 0"]
 
-
-    wf_loc = ac.EarthLocation.from_geocentric(      # Haystack westford antenna
-        x= 1492206.5970,
+    wf_loc = ac.EarthLocation.from_geocentric(  # Haystack westford antenna
+        x=1492206.5970,
         y=-4458130.5170,
-        z= 4296015.5320,
-        unit='m',
+        z=4296015.5320,
+        unit="m",
     )
 
-    ggao_loc = ac.EarthLocation.from_geocentric(    # Goddard, Greenbelt, Maryland
-         x=  1130794.76936,
-         y= -4831233.80170,
-         z=  3994217.03883,
-        unit='m',
+    ggao_loc = ac.EarthLocation.from_geocentric(  # Goddard, Greenbelt, Maryland
+        x=1130794.76936,
+        y=-4831233.80170,
+        z=3994217.03883,
+        unit="m",
     )
 
     # Add the site NRAO85, since this has multiple unique entries in ocean loading
     # that are distinguished by unique codes, while all having the same name.
     nrao85_3_loc = ac.EarthLocation.from_geodetic(
-        lon= 280.1566,
-        lat= 38.4296,
+        lon=280.1566,
+        lat=38.4296,
         height=785.847,
     )
     nrao85_1_loc = ac.EarthLocation.from_geodetic(
-        lon= 280.1718,
-        lat= 38.4359,
+        lon=280.1718,
+        lat=38.4359,
         height=807.687,
     )
 
@@ -92,10 +89,10 @@ def make_params(nsrcs=305, duration_min=10):
     srcs = ac.SkyCoord(
         az=np.random.uniform(0, 2 * np.pi, nsrcs),
         alt=np.random.uniform(np.radians(70), np.pi / 2, nsrcs),
-        unit='rad',
-        frame='altaz',
+        unit="rad",
+        frame="altaz",
         obstime=time,
-        location=gbo_loc
+        location=gbo_loc,
     )
     srcs = srcs.transform_to(ac.ICRS())
 
@@ -109,25 +106,31 @@ def make_params(nsrcs=305, duration_min=10):
 
     return kwargs
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def params_all():
     # One realization of parameters
     return make_params()
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def params_vlbi():
     # Keep stations in CALC database
     # (i.e., remove MWA and CHIME from lists).
     par = make_params()
-    par['station_coords'] = par['station_coords'][:-2]
-    par['station_names'] = par['station_names'][:-2]
+    par["station_coords"] = par["station_coords"][:-2]
+    par["station_names"] = par["station_names"][:-2]
     return par
 
 
-def run_calc_2x(calcf_kwargs={}, calcfile_name="temp.calc", base_mode="geocenter",
-               dry_atm=False, wet_atm=False):
-
-    quantities = ['delay', 'delay_rate', 'partials', 'times']
+def run_calc_2x(
+    calcf_kwargs={},
+    calcfile_name="temp.calc",
+    base_mode="geocenter",
+    dry_atm=False,
+    wet_atm=False,
+):
+    quantities = ["delay", "delay_rate", "partials", "times"]
 
     # Run with keywords
     ci = Calc(**calcf_kwargs, base_mode=base_mode, dry_atm=dry_atm, wet_atm=wet_atm)
@@ -137,7 +140,9 @@ def run_calc_2x(calcf_kwargs={}, calcfile_name="temp.calc", base_mode="geocenter
 
     # Run with calc file
     make_calc(**calcf_kwargs, ofile_name=calcfile_name)
-    ci = Calc(calc_file=calcfile_name, base_mode=base_mode, dry_atm=dry_atm, wet_atm=wet_atm)
+    ci = Calc(
+        calc_file=calcfile_name, base_mode=base_mode, dry_atm=dry_atm, wet_atm=wet_atm
+    )
     ci.run_driver()
     del ci.calc_file
     c0 = get_mod_state(calc)
@@ -147,7 +152,7 @@ def run_calc_2x(calcf_kwargs={}, calcfile_name="temp.calc", base_mode="geocenter
 
 
 def test_reset(params_vlbi):
-#   Reset works properly
+    #   Reset works properly
     stat0 = get_mod_state(calc)
     ci = Calc(**params_vlbi)
     assert not compare_dicts(stat0, get_mod_state(calc), quiet=True)
@@ -160,106 +165,122 @@ def test_reset(params_vlbi):
 
 @pytest.mark.parametrize("atmo", [True, False])
 def test_file_vs_kwds(atmo, params_vlbi, tmpdir):
-#   Module attributes match when run from calcfile or from keywords
-#   Delays, delay rates, partials match between calcfile and keywords
+    #   Module attributes match when run from calcfile or from keywords
+    #   Delays, delay rates, partials match between calcfile and keywords
     calcname = str(tmpdir.join("temp.calc"))
-    quants0, quants1, c0, c1 = run_calc_2x(calcf_kwargs=params_vlbi,
-                                           calcfile_name=calcname,
-                                           dry_atm=atmo, wet_atm=atmo)
+    quants0, quants1, c0, c1 = run_calc_2x(
+        calcf_kwargs=params_vlbi, calcfile_name=calcname, dry_atm=atmo, wet_atm=atmo
+    )
 
     # TODO -- Fix so these compare properly
-    #assert compare_dicts(c0, c1)
+    # assert compare_dicts(c0, c1)
 
-    quantities = ['delay', 'delay_rate', 'partials', 'times']
+    quantities = ["delay", "delay_rate", "partials", "times"]
     atols = {
-        'delay': 0.01 * un.ns,
-        'delay_rate': 1e-11 * un.s * un.Hz,
+        "delay": 0.01 * un.ns,
+        "delay_rate": 1e-11 * un.s * un.Hz,
     }
 
-    assert_quantity_allclose(quants0['delay'], quants1['delay'], atol=0.01*un.ns)
-    assert_quantity_allclose(quants0['delay_rate'], quants1['delay_rate'], atol=1e-11*un.s*un.Hz)
+    assert_quantity_allclose(quants0["delay"], quants1["delay"], atol=0.01 * un.ns)
+    assert_quantity_allclose(
+        quants0["delay_rate"], quants1["delay_rate"], atol=1e-11 * un.s * un.Hz
+    )
 
-    for nm in quants0['partials'].dtype.names:
-        if 'dDR' in nm:
-            atol = atols['delay_rate'] / un.rad
+    for nm in quants0["partials"].dtype.names:
+        if "dDR" in nm:
+            atol = atols["delay_rate"] / un.rad
         else:
-            atol = atols['delay'] / un.rad
-        assert_quantity_allclose(quants0['partials'][nm], quants1['partials'][nm], atol=atol)
+            atol = atols["delay"] / un.rad
+        assert_quantity_allclose(
+            quants0["partials"][nm], quants1["partials"][nm], atol=atol
+        )
 
-    assert np.all(quants0['times'] == quants1['times'])
+    assert np.all(quants0["times"] == quants1["times"])
 
 
 def test_calc_props(params_vlbi):
-#   Calc attributes match passed params
+    #   Calc attributes match passed params
     ci = Calc(**params_vlbi)
     srcs = ci.source_coords
-    psrcs = ac.SkyCoord(params_vlbi['source_coords'])
+    psrcs = ac.SkyCoord(params_vlbi["source_coords"])
 
     # Source positions
     assert_allclose(srcs.ra.rad, psrcs.ra.rad)
     assert_allclose(srcs.dec.rad, psrcs.dec.rad)
 
     # Station positions
-    stats = [ac.EarthLocation.from_geocentric(*c, unit='m') for c in ci.station_coords.T]
-    assert all([stats[ci] == loc for ci, loc in enumerate(params_vlbi['station_coords'])])
+    stats = [
+        ac.EarthLocation.from_geocentric(*c, unit="m") for c in ci.station_coords.T
+    ]
+    assert all(
+        [stats[ci] == loc for ci, loc in enumerate(params_vlbi["station_coords"])]
+    )
 
 
 @pytest.mark.filterwarnings("ignore:No ocean")
 def test_kwd_override(params_all, tmpdir):
-#   Providing calc file and keywords --> Keywords override .calc file
+    #   Providing calc file and keywords --> Keywords override .calc file
     calcfile_name = str(tmpdir.join("temp.calc"))
     make_calc(**params_all, ofile_name=calcfile_name)
 
     # Remove a station
-    stat_locs = params_all['station_coords'][:-1]
-    stat_nmes = params_all['station_names'][:-1]
+    stat_locs = params_all["station_coords"][:-1]
+    stat_nmes = params_all["station_names"][:-1]
 
-    ci = Calc(calc_file=calcfile_name, station_coords=stat_locs, station_names=stat_nmes)
+    ci = Calc(
+        calc_file=calcfile_name, station_coords=stat_locs, station_names=stat_nmes
+    )
     assert ci.station_coords.shape[1] == len(stat_locs) == 8
 
 
-@pytest.mark.skip("Can't set tolerance due to some systematic with astropy."
-                  " To be explored further.")
-@pytest.mark.parametrize("base_mode", ['geocenter', 'baseline'])
+@pytest.mark.parametrize("base_mode", ["geocenter", "baseline"])
 def test_ddr_vals(base_mode, params_vlbi):
-#   > D, DR are close to expectation from a rough astropy calculation.
-#   (Eventually, set tolerances based on expected astropy accuracy.)
+    #   > D, DR are close to expectation from a rough astropy calculation.
+    #   (Eventually, set tolerances based on expected astropy accuracy.)
     pars = deepcopy(params_vlbi)
+
     # remove CHIME, because the one ~3000 km NW -- SE baseline is creating some
     # weird conditions with sources too near the horizon.
-    pars['station_names'] = pars['station_names'][1:]
-    pars['station_coords'] = pars['station_coords'][1:]
+    pars["station_names"] = pars["station_names"][1:]
+    pars["station_coords"] = pars["station_coords"][1:]
     ci = Calc(**pars, base_mode=base_mode, dry_atm=False, wet_atm=False)
     ci.run_driver()
-    st_nmes = pars['station_names']
-    st_locs = pars['station_coords']
-    srcs = ac.SkyCoord(params_vlbi['source_coords'])
+    st_nmes = pars["station_names"]
+    st_locs = pars["station_coords"]
+    srcs = ac.SkyCoord(params_vlbi["source_coords"])
     nstat = len(st_nmes)
-    gc = ac.EarthLocation.from_geocentric(0,0,0, unit='m')
+    gc = ac.EarthLocation.from_geocentric(0, 0, 0, unit="m")
+
+    # TODO -- check that the tolerances are sensible, especially delay rate
+    #   > Do we expect O(5 us) errors on delay from astropy?
+
     for ti, tt in enumerate(ci.times):
-        if base_mode == 'geocenter':
+        if base_mode == "geocenter":
             for si in range(nstat):
                 ap_del = astropy_delay(srcs, tt, st_locs[si], gc)
                 ap_dlr = astropy_delay_rate(srcs, tt, st_locs[si], gc)
-                ra,dec = ci.source_coords
-                assert_quantity_allclose(ci.delay[ti, 0, si, :], ap_del, rtol=0.05)
-                assert_quantity_allclose(ap_dlr, ci.delay_rate[ti, 0, si, :], rtol=0.05)
-        if base_mode == 'baseline':
+                assert_quantity_allclose(ci.delay[ti, 0, si, :], ap_del, atol=5 * un.us)
+                assert_quantity_allclose(ap_dlr, ci.delay_rate[ti, 0, si, :], atol=1e-11 * un.s * un.Hz)
+        if base_mode == "baseline":
             for s1i in range(nstat):
-                for s2i in range(s1i, nstat-1):
+                for s2i in range(s1i+1, nstat):
                     ap_del = astropy_delay(srcs, tt, st_locs[s2i], st_locs[s1i])
                     ap_dlr = astropy_delay_rate(srcs, tt, st_locs[s2i], st_locs[s1i])
-                    assert_quantity_allclose(ci.delay[ti, s1i, s2i, :], ap_del, rtol=0.05)
-                    assert_quantity_allclose(ap_dlr, ci.delay_rate[ti, s1i, s2i, :], rtol=0.05)
+                    assert_quantity_allclose(
+                        ci.delay[ti, s1i, s2i, :], ap_del, atol=5 * un.us
+                    )
+                    assert_quantity_allclose(
+                        ap_dlr, ci.delay_rate[ti, s1i, s2i, :], atol=1e-11 * un.s * un.Hz
+                    )
 
 
 def test_oc_warnings(params_all):
-#   Check that OceanFiles.check_sites warns about the correct sites being missing
-#   from ocean loading and ocean pole tide loading files.
+    #   Check that OceanFiles.check_sites warns about the correct sites being missing
+    #   from ocean loading and ocean pole tide loading files.
 
-#   TODO I shouldn't need to use the full setup to run this test. Rewrite to just use dinit
-#          to run the file parser in CALC (filling oc_coefs_found) before comparing with
-#          OceanFiles.check_sites.
+    #   TODO I shouldn't need to use the full setup to run this test. Rewrite to just use dinit
+    #          to run the file parser in CALC (filling oc_coefs_found) before comparing with
+    #          OceanFiles.check_sites.
 
     with warnings.catch_warnings(record=True) as warning_list:
         ci = Calc(**params_all)
@@ -270,20 +291,24 @@ def test_oc_warnings(params_all):
     oc_bad0 = []
     optl_bad0 = []
     for msg in msgs:
-        ants = [a.strip().ljust(8)[:8] for a in msg.split('for ')[1].split(',')]
+        ants = [a.strip().ljust(8)[:8] for a in msg.split("for ")[1].split(",")]
         if "ocean loading" in msg:
             oc_bad0 += ants
         if "ocean pole tide" in msg:
             optl_bad0 += ants
 
-    oc_bad0 = np.asarray(oc_bad0, dtype='<U8')
-    optl_bad0 = np.asarray(optl_bad0, dtype='<U8')
+    oc_bad0 = np.asarray(oc_bad0, dtype="<U8")
+    optl_bad0 = np.asarray(optl_bad0, dtype="<U8")
     # calc.sitcm.oc_coefs_found[0, ii] == 1 if calc.calc_input.sites[ii] found in
     #   ocean pole tide loading coefficients file
     # calc.sitcm.oc_coefs_found[1, ii] == 1 if calc.calc_input.sites[ii] found in
     #   ocean loading data file.
-    oc_bad = ci.station_names[~calc.sitcm.oc_coefs_found[1][1:ci.nants+1].astype(bool)]
-    optl_bad = ci.station_names[~calc.sitcm.oc_coefs_found[0][1:ci.nants+1].astype(bool)]
+    oc_bad = ci.station_names[
+        ~calc.sitcm.oc_coefs_found[1][1 : ci.nants + 1].astype(bool)
+    ]
+    optl_bad = ci.station_names[
+        ~calc.sitcm.oc_coefs_found[0][1 : ci.nants + 1].astype(bool)
+    ]
 
     for l in [oc_bad0, oc_bad, optl_bad0, optl_bad]:
         l.sort()
@@ -296,14 +321,15 @@ def test_oc_dist_warnings(params_all):
     # Last one is assumed to be at DRAO, but given to calc as algo. Should give big offset.
     with warnings.catch_warnings(record=True) as warning_list:
         OceanFiles.check_sites(
-            site_names=params_all['station_names'], site_pos=params_all['station_coords']
+            site_names=params_all["station_names"],
+            site_pos=params_all["station_coords"],
         )
 
     print([str(wn.message) for wn in warning_list])
     for w in (str(wn.message) for wn in warning_list):
         if "Station positions" in w:
-            assert all([st in w for st in ['VLA_E9', 'ALMA']])
-            assert all([st not in w for st in ['GBT-VLBA']])
+            assert all([st in w for st in ["VLA_E9", "ALMA"]])
+            assert all([st not in w for st in ["GBT-VLBA"]])
 
 
 def test_partials_calc(params_vlbi):
@@ -317,11 +343,12 @@ def test_partials_calc(params_vlbi):
     srcs = ac.SkyCoord(
         ra=[c_ra, c_ra, c_ra, c_ra - dth, c_ra + dth],
         dec=[c_dec, c_dec - dth, c_dec + dth, c_dec, c_dec],
-        unit='rad', frame='icrs'
+        unit="rad",
+        frame="icrs",
     )
 
     pars = deepcopy(params_vlbi)
-    pars['source_coords'] = srcs
+    pars["source_coords"] = srcs
 
     ci = Calc(**pars, dry_atm=False, wet_atm=False)
     ci.run_driver()
@@ -337,8 +364,10 @@ def test_partials_calc(params_vlbi):
 
     # dtau_dra and dtau_ddec axes = (time, ant1, ant2) where ant1 is just geocenter
     atol = 1e-6 * un.s / un.rad
-    assert_quantity_allclose(dtau_dra[:, 0, :], partials['dD_dRA'][:, 0, :], atol=atol)
-    assert_quantity_allclose(dtau_ddec[:, 0, :], partials['dD_dDEC'][:, 0, :], atol=atol)
+    assert_quantity_allclose(dtau_dra[:, 0, :], partials["dD_dRA"][:, 0, :], atol=atol)
+    assert_quantity_allclose(
+        dtau_ddec[:, 0, :], partials["dD_dDEC"][:, 0, :], atol=atol
+    )
 
 
 def test_errors(params_all):
@@ -352,18 +381,18 @@ def test_errors(params_all):
         ci.delay
 
 
-@pytest.mark.skipif(difxcalc is None, reason='difxcalc must be installed for this test')
+@pytest.mark.skipif(difxcalc is None, reason="difxcalc must be installed for this test")
 def test_compare_to_difxcalc(params_vlbi, tmpdir):
     # Compare running Calc here with results from a separately-installed difxcalc.
 
     # Difxcalc can't handle more than 300 sources
     # Just keep ten sources for this test.
-    params_vlbi['source_coords'] = params_vlbi['source_coords'][:10]
+    params_vlbi["source_coords"] = params_vlbi["source_coords"][:10]
 
-    params_vlbi['duration_min'] = 20
+    params_vlbi["duration_min"] = 20
 
-    quantities = ['delay', 'delay_rate', 'partials', 'times']
-    ci = Calc(**params_vlbi, base_mode='geocenter', dry_atm=False, wet_atm=False)
+    quantities = ["delay", "delay_rate", "partials", "times"]
+    ci = Calc(**params_vlbi, base_mode="geocenter", dry_atm=False, wet_atm=False)
     ci.run_driver()
     quants1 = {q: getattr(ci, q).copy() for q in quantities}
 
@@ -373,9 +402,9 @@ def test_compare_to_difxcalc(params_vlbi, tmpdir):
     impath = run_difxcalc(calcname, verbose=False)
 
     im_obj = CalcReader(impath)
-    times = Time(quants1['times'])
+    times = Time(quants1["times"])
 
-    delays = -quants1['delay'].to_value('us')# * (-1e6)
+    delays = -quants1["delay"].to_value("us")  # * (-1e6)
     im_dels = np.zeros_like(delays)
     for ti, tt in enumerate(times):
         for si in range(10):
@@ -393,27 +422,37 @@ def test_coef_vals(params_vlbi):
     with warnings.catch_warnings():
         ci = Calc(**params_vlbi)
 
-    nants = len(params_vlbi['station_coords'])
-    names = params_vlbi['station_names']
+    nants = len(params_vlbi["station_coords"])
+    names = params_vlbi["station_names"]
     inds = [OceanFiles.get_oc_ind(n)[0] for n in names]
 
     # Phases are given as deg in the file, but converted to rad in CALC.
-    coefs = np.rollaxis(np.stack((
-        calc.sitcm.sitoam[..., 1:nants + 1],    # Vertical amplitude [m]
-        calc.sitcm.sithoa[:, 0, 1:nants + 1],   # horizontal amplitudes [m]
-        calc.sitcm.sithoa[:, 1, 1:nants + 1],
-        np.degrees(calc.sitcm.sitoph[..., 1:nants + 1]),  # Vertical phase [deg]
-        np.degrees(calc.sitcm.sithop[:, 0, 1:nants + 1]), # horizontal phases [deg]
-        np.degrees(calc.sitcm.sithop[:, 1, 1:nants + 1]),
-    )), 2, 0)
+    coefs = np.rollaxis(
+        np.stack(
+            (
+                calc.sitcm.sitoam[..., 1 : nants + 1],  # Vertical amplitude [m]
+                calc.sitcm.sithoa[:, 0, 1 : nants + 1],  # horizontal amplitudes [m]
+                calc.sitcm.sithoa[:, 1, 1 : nants + 1],
+                np.degrees(
+                    calc.sitcm.sitoph[..., 1 : nants + 1]
+                ),  # Vertical phase [deg]
+                np.degrees(
+                    calc.sitcm.sithop[:, 0, 1 : nants + 1]
+                ),  # horizontal phases [deg]
+                np.degrees(calc.sitcm.sithop[:, 1, 1 : nants + 1]),
+            )
+        ),
+        2,
+        0,
+    )
 
     # Compare the above to the corresponding values in OceanFiles.oc_data['coefs']
-    assert_allclose(coefs, OceanFiles.oc_data['coefs'][inds])
+    assert_allclose(coefs, OceanFiles.oc_data["coefs"][inds])
 
     # Now compare ocean pole tide loading coefs
-    keys = ['urr', 'uri', 'unr', 'uni', 'uer', 'uei']
+    keys = ["urr", "uri", "unr", "uni", "uer", "uei"]
     inds = [OceanFiles.get_optl_ind(n)[0] for n in names]
-    coefs = calc.sitcm.optl6[:, 1:nants+1]
+    coefs = calc.sitcm.optl6[:, 1 : nants + 1]
     comp = np.zeros_like(coefs)
     for ii in range(nants):
         comp[:, ii] = OceanFiles.optl_data[keys][inds][ii].tolist()
@@ -429,15 +468,17 @@ def test_change_quantities(params_vlbi, kv):
     setattr(ci, key, val)
     assert ci._rerun
 
-    with pytest.raises(ValueError, match="Need to rerun adrivr before accessing data. "):
+    with pytest.raises(
+        ValueError, match="Need to rerun adrivr before accessing data. "
+    ):
         print(ci.delay)
 
-    if key == 'source_coords':
+    if key == "source_coords":
         ci.run_driver()
         assert ci.nsrcs == 30
         assert ci.delay.shape[-1] == 30
 
 
+
 ## TODO
 #   Test that epochs cover the requested scan times
-#   Fix tests with astropy comparison

--- a/pycalc11/tests/test_calc.py
+++ b/pycalc11/tests/test_calc.py
@@ -420,6 +420,7 @@ def test_compare_to_difxcalc(params_vlbi, tmpdir):
 def test_coef_vals(params_vlbi):
     # Check that coefficient values found by OceanFiles match those loaded by calc.
     with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
         ci = Calc(**params_vlbi)
 
     nants = len(params_vlbi["station_coords"])
@@ -478,7 +479,13 @@ def test_change_quantities(params_vlbi, kv):
         assert ci.nsrcs == 30
         assert ci.delay.shape[-1] == 30
 
-
-
-## TODO
-#   Test that epochs cover the requested scan times
+def test_epochs():
+    # Check that scan covers requested time
+    pars = make_params(nsrcs=10, duration_min=60)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        ci = Calc(**pars)
+    ci.run_driver()
+    t0 = pars["start_time"]
+    t1 = t0 + TimeDelta(3600, format='sec')
+    assert ci.times.min() <= t0 and t1 <= ci.times.max()


### PR DESCRIPTION
A larger change that ensures changes to any simulation parameter (e.g., stations coordinates, time, sources) will reset associated other parameters (EOPs, scan info, etc.) before rerunning. This is achieved by making the setters for the various properties do the work of older (removed) functions like set_eops and set_stations.

Also fixes and adds some tests.

Breaking changes:
 - "src_names" is no longer a keyword. Sources do not need to have names, so this is removed. Source names may be returned in a future version, passed in via the `SkyCoord.info.name` parameter.
 - "src_coords" is now "source_coords". The main object to handle sources is just a SkyCoord.
 - "stat_coords" and "stat_names" attributes are now "station_***"
 - "time" keyword is now called "start_time"
 - "reset" function is now hidden