### PR TITLE
Enable JPL ephem and set meteorological data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,6 @@ Install directly from the repository with pip::
 The source code for CALC is in the repository and will be built and added as an
 extension to the pycalc11 module.
 
-On a first run, `pycalc11` will download and cache the JPL DE421 ephemeris file from a GitHub repository for difx. This can take around 30s.
-
 NOTE: Tests of the MacOS installation are currently failing.
      This seems to be due to some issue with gcc on the latest Mac versions. If you have trouble installing on a Mac, it's an issue with the build environment. See https://github.com/aelanman/pycalc11/issues/18
 
@@ -81,7 +79,7 @@ instance, and duration as a float representing the length of the scan in minutes
         station_names=site_names,
         station_coords=site_locs,
         source_coords=source_coords,
-        time=time,
+        start_time=time,
         duration_min=duration_min,
     )
 

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,15 @@ Install directly from the repository with pip::
 The source code for CALC is in the repository and will be built and added as an
 extension to the pycalc11 module.
 
+On first use, `pycalc11` will download and cache a JPL SPK ephemeris kernel from NAIF/JPL. By
+default this is ``de440s`` (~32 MB), read in Python via ``jplephem``. A different ephemeris may be
+selected with the ``ephemeris`` parameter, either by name (e.g. ``'de421'``, ``'de440'``, ``'de441'``)
+or as a path to an SPK (``.bsp``) file.
+
+The original Fortran DE421 binary reader is retained as a legacy option, selected with
+``ephemeris='legacy'``. It downloads the DE421 binary from the difx GitHub mirror and pins results
+to the superseded DE421 ephemeris; it is kept mainly for reproducing older results.
+
 NOTE: Tests of the MacOS installation are currently failing.
      This seems to be due to some issue with gcc on the latest Mac versions. If you have trouble installing on a Mac, it's an issue with the build environment. See https://github.com/aelanman/pycalc11/issues/18
 

--- a/ci/cache_data.py
+++ b/ci/cache_data.py
@@ -1,5 +1,5 @@
 """
-Cache DE421 kernel data and
+Cache ephemeris and IERS data for CI.
 """
 
 from astropy.utils.data import (
@@ -15,13 +15,27 @@ import sys
 home = os.path.expanduser("~")
 cache_file = os.path.join(home, "astropy_cache.zip")
 
+# JPL SPK kernels read in Python via jplephem. 'de440s' is the default
+# ephemeris; 'de421' is used by the ephemeris comparison tests.
+_SPK_URLS = [
+    "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp",
+    "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de421.bsp",
+]
+
+# Legacy Fortran DE421 binary reader (ephemeris="legacy").
+_DE421_URL = (
+    "https://github.com/difx/difx/raw/refs/heads/main/"
+    f"applications/difxcalc11/data/DE421_{sys.byteorder}_Endian"
+)
+
 # Download iers data
 Time.now().ut1
 
 if sys.argv[1] == "save":
     if not os.path.exists(cache_file):
-        de421_url = f"https://github.com/difx/difx/raw/refs/heads/main/applications/difxcalc11/data/DE421_{sys.byteorder}_Endian"
-        de421_path = download_file(de421_url, cache=True)
+        for url in _SPK_URLS:
+            download_file(url, cache=True)
+        download_file(_DE421_URL, cache=True)
         urls = get_cached_urls()
         export_download_cache(cache_file, urls=urls, overwrite=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ license = {text = "MIT"}
 description = "Python wrappers for CALC11"
 urls = {Homepage = "https://github.com/aelanman/pycalc11"}
 requires-python = ">=3.8"
-dependencies = ["numpy>=1.21", "astropy>=3.2", "scipy"]
+dependencies = ["numpy>=1.21", "astropy>=3.2", "scipy", "jplephem"]
 
 [project.optional-dependencies]
-dev = ["pytest", "flake8", "pycodestyle", "jplephem"]
+dev = ["pytest", "flake8", "pycodestyle"]
 
 [tool.setuptools_scm]
 

--- a/src/calc11/adrvr.f
+++ b/src/calc11/adrvr.f
@@ -1,6 +1,7 @@
       SUBROUTINE aDRIVR(Iscan,J2m)
       use outputs
       use srcmod
+      use metmod
       IMPLICIT None
 !
 ! 1.    DRIVR
@@ -799,6 +800,29 @@
 !    For difx, only the atmosphere partials are needed.
 !    The others are left for future use but commented out.
 !
+!     Copy station-indexed met data into the 2-element baseline arrays
+!     used by ATMP, if external met data has been provided.
+      If (use_ext_met) Then
+        SurPR(1,1) = ext_pressure(Istation1)
+        SurPR(1,2) = 0.D0
+        SurPR(2,1) = ext_pressure(Istation2)
+        SurPR(2,2) = 0.D0
+        SurTP(1,1) = ext_temperature(Istation1)
+        SurTP(1,2) = 0.D0
+        SurTP(2,1) = ext_temperature(Istation2)
+        SurTP(2,2) = 0.D0
+        SurHM(1,1) = ext_humidity(Istation1)
+        SurHM(1,2) = 0.D0
+        SurHM(2,1) = ext_humidity(Istation2)
+        SurHM(2,2) = 0.D0
+        metPR = 1
+        metTP = 1
+        metHM = 1
+      Else
+        metPR = 0
+        metTP = 0
+        metHM = 0
+      Endif
 !     Compute the atmosphere partials.
       CALL ATMP (SITLAT, SITLON, SITHEIGHT, XJD, CT, dATMCdh,           &
      &     gmfh, gmfw)

--- a/src/calc11/cpepu.f
+++ b/src/calc11/cpepu.f
@@ -1,5 +1,6 @@
 !*************************************************************************
       SUBROUTINE PEP ( XJD, ET, TSKIP, EARTH, SUN, XMOON )
+      use ephcom
       IMPLICIT None
 !
 ! 4.    PEP
@@ -190,6 +191,40 @@
 !
 !    Compute new values or use previous values?
        IF (TSKIP .eq. 1) Go to 510
+!
+!     Use externally-provided ephemeris data if available
+      IF (use_ext_ephem) THEN
+        do i=1,3
+          earth(i,1) = ext_earth(i,1,eph_step_idx)
+          earth(i,2) = ext_earth(i,2,eph_step_idx)
+          earth(i,3) = ext_earth(i,3,eph_step_idx)
+          earth1(i,1) = earth(i,1)
+          earth1(i,2) = earth(i,2)
+          earth1(i,3) = earth(i,3)
+          sun(i,1) = ext_sun(i,1,eph_step_idx)
+          sun(i,2) = ext_sun(i,2,eph_step_idx)
+          sun1(i,1) = sun(i,1)
+          sun1(i,2) = sun(i,2)
+          SUNb(i,1) = ext_sunb(i,1,eph_step_idx)
+          SUNb(i,2) = ext_sunb(i,2,eph_step_idx)
+          xmoon(i,1) = ext_xmoon(i,1,eph_step_idx)
+          xmoon(i,2) = ext_xmoon(i,2,eph_step_idx)
+          xmoon1(i,1) = xmoon(i,1)
+          xmoon1(i,2) = xmoon(i,2)
+          MOONb(i,1) = ext_moonb(i,1,eph_step_idx)
+          MOONb(i,2) = ext_moonb(i,2,eph_step_idx)
+        enddo
+        do k=1,7
+          do i=1,3
+            SPLANET(i,1,k) = ext_splanet(i,1,k,eph_step_idx)
+            SPLANET(i,2,k) = ext_splanet(i,2,k,eph_step_idx)
+            GPLANET(i,1,k) = ext_gplanet(i,1,k,eph_step_idx)
+            GPLANET(i,2,k) = ext_gplanet(i,2,k,eph_step_idx)
+          enddo
+        enddo
+        eph_step_idx = eph_step_idx + 1
+        Go to 510
+      ENDIF
 !
 !     Get the solar system geometry of the current observation from the
 !     DE/LE405 file.

--- a/src/calc11/data_module.f
+++ b/src/calc11/data_module.f
@@ -84,3 +84,23 @@
       Real*8 :: ext_moonb(3,2,MAX_EPH_STEPS)
 !
       end module ephcom
+
+      MODULE metmod
+      implicit none
+!
+!     Module to hold externally-provided (Python-side) surface
+!     meteorological data, indexed by station number.
+!
+!     Control flag: .true. = use Python-provided met data
+      logical :: use_ext_met = .false.
+!
+!     Maximum number of stations (must match Max_Stat in cmxst11.i)
+      Integer*4, parameter :: MAX_MET_STAT = 41
+!
+!     Surface pressure (mbar), temperature (deg C), relative humidity (0-1)
+!     per station.  Index runs over station number in the Calc site list.
+      Real*8 :: ext_pressure(MAX_MET_STAT)
+      Real*8 :: ext_temperature(MAX_MET_STAT)
+      Real*8 :: ext_humidity(MAX_MET_STAT)
+!
+      end module metmod

--- a/src/calc11/data_module.f
+++ b/src/calc11/data_module.f
@@ -48,7 +48,39 @@
 
       end module datafiles
 
-!      MODULE stations
-!      implicit none
+      MODULE ephcom
+      implicit none
 !
-!      end module stations
+!     Module to hold externally-provided (Python-side) ephemeris data,
+!     allowing PEP to bypass the Fortran binary DE file reading.
+!
+!     Control flag: .true. = use Python-provided ephemeris data
+      logical :: use_ext_ephem = .false.
+!
+!     Maximum number of time steps per 2-minute epoch.
+!     Typical value is 6 (for 24s intervals over 2 min).
+!     150 covers d_interval as small as ~0.8s.
+      Integer*4, parameter :: MAX_EPH_STEPS = 150
+!
+!     Step counter, reset from Python before each adrivr call.
+      Integer*4 :: eph_step_idx = 1
+!
+!     Pre-computed PEP outputs for each time step.
+!     All in meters, m/s, m/s^2, J2000.0 frame.
+!
+!     Barycentric Earth position, velocity, acceleration
+      Real*8 :: ext_earth(3,3,MAX_EPH_STEPS)
+!     Geocentric Sun position, velocity
+      Real*8 :: ext_sun(3,2,MAX_EPH_STEPS)
+!     Geocentric Moon position, velocity
+      Real*8 :: ext_xmoon(3,2,MAX_EPH_STEPS)
+!     Barycentric planet positions, velocities (7 planets)
+      Real*8 :: ext_splanet(3,2,7,MAX_EPH_STEPS)
+!     Geocentric planet positions, velocities (7 planets)
+      Real*8 :: ext_gplanet(3,2,7,MAX_EPH_STEPS)
+!     Barycentric Sun position, velocity
+      Real*8 :: ext_sunb(3,2,MAX_EPH_STEPS)
+!     Barycentric Moon position, velocity
+      Real*8 :: ext_moonb(3,2,MAX_EPH_STEPS)
+!
+      end module ephcom

--- a/src/pycalc11/__init__.py
+++ b/src/pycalc11/__init__.py
@@ -7,10 +7,23 @@ from . import calc11
 from . import runner
 
 
-# Get JPL ephemeris data (DE421 binary for the default Fortran path)
-de421_url = f"https://svn.atnf.csiro.au/difx/applications/difxcalc11/trunk/data/DE421_{sys.byteorder}_Endian"
-de421_path = download_file(de421_url, cache=True)
-calc11.datafiles.jpl_de421 = de421_path.ljust(128)
+# DE421 binary URL for the default Fortran ephemeris reader
+_DE421_URL = f"https://svn.atnf.csiro.au/difx/applications/difxcalc11/trunk/data/DE421_{sys.byteorder}_Endian"
+_de421_loaded = False
+
+
+def _ensure_de421():
+    """Download and set the DE421 binary path if not already done.
+
+    Called lazily before the Fortran initializer needs it, so that
+    ``import pycalc11`` does not require network access.
+    """
+    global _de421_loaded
+    if _de421_loaded:
+        return
+    de421_path = download_file(_DE421_URL, cache=True)
+    calc11.datafiles.jpl_de421 = de421_path.ljust(128)
+    _de421_loaded = True
 
 
 def _format(fname):

--- a/src/pycalc11/__init__.py
+++ b/src/pycalc11/__init__.py
@@ -66,10 +66,9 @@ def get_spk(name="de440s"):
     """
     name = name.lower()
     if name not in _SPK_URLS:
-        raise ValueError(
-            f"Unknown ephemeris '{name}'. Available: {list(_SPK_URLS.keys())}"
-        )
+        raise ValueError(f"Unknown ephemeris '{name}'. Available: {list(_SPK_URLS.keys())}")
     return download_file(_SPK_URLS[name], cache=True)
+
 
 get_spk.__doc__ = get_spk.__doc__.replace("SPK_AVAIL", "'" + "', '".join(list(_SPK_URLS)) + "'")
 

--- a/src/pycalc11/__init__.py
+++ b/src/pycalc11/__init__.py
@@ -7,8 +7,8 @@ from . import calc11
 from . import runner
 
 
-# Get JPL ephemeris data
-de421_url = f"https://github.com/difx/difx/raw/refs/heads/main/applications/difxcalc11/data/DE421_{sys.byteorder}_Endian"
+# Get JPL ephemeris data (DE421 binary for the default Fortran path)
+de421_url = f"https://svn.atnf.csiro.au/difx/applications/difxcalc11/trunk/data/DE421_{sys.byteorder}_Endian"
 de421_path = download_file(de421_url, cache=True)
 calc11.datafiles.jpl_de421 = de421_path.ljust(128)
 
@@ -24,6 +24,40 @@ calc11.datafiles.oc_file = _format("ocean_load.coef")
 calc11.datafiles.optl_file = _format("ocean_pole_tide.coef")
 calc11.datafiles.dfleap = _format("ut1ls.dat")
 
+
+# Known SPK ephemeris URLs from NAIF/JPL
+_SPK_URLS = {
+    "de421": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/de421.bsp",
+    "de430": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de430.bsp",
+    "de440": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440.bsp",
+    "de440s": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp",
+    "de441": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de441.bsp",
+}
+
+
+def get_spk(name="de440s"):
+    """Download a JPL SPK ephemeris file.
+
+    Parameters
+    ----------
+    name : str
+        Ephemeris name (e.g., 'de421', 'de430', 'de440', 'de440s', 'de441').
+        The 's' variants (e.g., 'de440s') are smaller files covering a shorter
+        time span and are recommended for typical use.
+
+    Returns
+    -------
+    str
+        Path to the cached SPK file.
+    """
+    name = name.lower()
+    if name not in _SPK_URLS:
+        raise ValueError(
+            f"Unknown ephemeris '{name}'. Available: {list(_SPK_URLS.keys())}"
+        )
+    return download_file(_SPK_URLS[name], cache=True)
+
+
 from .interface import Calc
 
-__all__ = ["Calc", "DATA_PATH", "calc11", "runner"]
+__all__ = ["Calc", "DATA_PATH", "calc11", "runner", "get_spk"]

--- a/src/pycalc11/__init__.py
+++ b/src/pycalc11/__init__.py
@@ -7,21 +7,37 @@ from . import calc11
 from . import runner
 
 
-# DE421 binary URL for the default Fortran ephemeris reader
-_DE421_URL = f"https://svn.atnf.csiro.au/difx/applications/difxcalc11/trunk/data/DE421_{sys.byteorder}_Endian"
+# Default ephemeris used when none is specified. This is a JPL SPK kernel
+# read in Python via jplephem (see get_spk / Calc._setup_ephemeris).
+DEFAULT_EPHEMERIS = "de440s"
+
+# Legacy DE421 binary URL for the Fortran ephemeris reader (ephemeris="legacy").
+# Served from the difx GitHub mirror (the original ATNF SVN host is defunct).
+# Override this value if the file location changes.
+_DE421_URL = f"https://github.com/difx/difx/raw/refs/heads/main/applications/difxcalc11/data/DE421_{sys.byteorder}_Endian"
 _de421_loaded = False
 
 
 def _ensure_de421():
-    """Download and set the DE421 binary path if not already done.
+    """Download and set the legacy DE421 binary path if not already done.
 
-    Called lazily before the Fortran initializer needs it, so that
-    ``import pycalc11`` does not require network access.
+    Only used by the legacy Fortran ephemeris reader (``ephemeris="legacy"``).
+    Called lazily so that ``import pycalc11`` and the default JPL SPK path do
+    not require this (potentially unavailable) download.
     """
     global _de421_loaded
     if _de421_loaded:
         return
-    de421_path = download_file(_DE421_URL, cache=True)
+    try:
+        de421_path = download_file(_DE421_URL, cache=True)
+    except Exception as err:
+        raise RuntimeError(
+            "Could not download the legacy DE421 binary from\n"
+            f"    {_DE421_URL}\n"
+            "Use the default JPL ephemeris instead (omit the `ephemeris` "
+            "argument, or pass a name like 'de421'/'de440s'), or override "
+            "pycalc11._DE421_URL to point at an available mirror."
+        ) from err
     calc11.datafiles.jpl_de421 = de421_path.ljust(128)
     _de421_loaded = True
 
@@ -74,4 +90,4 @@ get_spk.__doc__ = get_spk.__doc__.replace("SPK_AVAIL", "'" + "', '".join(list(_S
 
 from .interface import Calc
 
-__all__ = ["Calc", "DATA_PATH", "calc11", "runner", "get_spk"]
+__all__ = ["Calc", "DATA_PATH", "calc11", "runner", "get_spk", "DEFAULT_EPHEMERIS"]

--- a/src/pycalc11/__init__.py
+++ b/src/pycalc11/__init__.py
@@ -41,7 +41,8 @@ def get_spk(name="de440s"):
     Parameters
     ----------
     name : str
-        Ephemeris name (e.g., 'de421', 'de430', 'de440', 'de440s', 'de441').
+        Ephemeris name
+        Options: SPK_AVAIL
         The 's' variants (e.g., 'de440s') are smaller files covering a shorter
         time span and are recommended for typical use.
 
@@ -57,6 +58,7 @@ def get_spk(name="de440s"):
         )
     return download_file(_SPK_URLS[name], cache=True)
 
+get_spk.__doc__ = get_spk.__doc__.replace("SPK_AVAIL", "'" + "', '".join(list(_SPK_URLS)) + "'")
 
 from .interface import Calc
 

--- a/src/pycalc11/ephemeris.py
+++ b/src/pycalc11/ephemeris.py
@@ -1,4 +1,4 @@
-""Ephemeris computation using jplephem SPK kernels."""
+"""Ephemeris computation using jplephem SPK kernels."""
 
 import numpy as np
 

--- a/src/pycalc11/ephemeris.py
+++ b/src/pycalc11/ephemeris.py
@@ -1,0 +1,111 @@
+""Ephemeris computation using jplephem SPK kernels."""
+
+import numpy as np
+
+
+# JPL planet indices used by PEP's SPLANET/GPLANET arrays:
+#   1=Mercury, 2=Venus, 3=Mars, 4=Jupiter, 5=Saturn, 6=Uranus, 7=Neptune
+# Corresponding SPK segment center-target pairs (SSB -> body):
+_PLANET_SPK_TARGETS = [1, 2, 4, 5, 6, 7, 8]
+
+# Conversion factor: km/day -> m/s
+_KM_PER_DAY_TO_M_PER_S = 1.0e3 / 86400.0
+
+
+def _compute_earth_ssb(kernel, tdb_jd):
+    """Compute Earth SSB position (km) and velocity (km/day)."""
+    emb_pos, emb_vel = kernel[0, 3].compute_and_differentiate(tdb_jd)
+    e_from_emb_pos, e_from_emb_vel = kernel[3, 399].compute_and_differentiate(tdb_jd)
+    return emb_pos + e_from_emb_pos, emb_vel + e_from_emb_vel
+
+
+def fill_ephem_arrays(kernel, tdb_jd_array, calc_module):
+    """Pre-compute ephemeris and fill Fortran ephcom arrays for a set of time steps.
+
+    Computes all the quantities that the Fortran PEP subroutine normally produces
+    (Earth, Sun, Moon, and planet positions/velocities) using a jplephem SPK kernel,
+    and writes them into the calc11.ephcom module arrays.
+
+    Parameters
+    ----------
+    kernel : jplephem.spk.SPK
+        An open JPL SPK ephemeris kernel.
+    tdb_jd_array : array_like
+        TDB Julian dates for each time step. Length must not exceed
+        calc_module.ephcom.max_eph_steps.
+    calc_module : module
+        The compiled calc11 Fortran module (typically ``pycalc11.calc11``).
+    """
+    tdb_jd = np.atleast_1d(np.asarray(tdb_jd_array, dtype=np.float64))
+    n_steps = len(tdb_jd)
+
+    eph = calc_module.ephcom
+    if n_steps > eph.ext_earth.shape[2]:
+        raise ValueError(
+            f"Number of time steps ({n_steps}) exceeds Fortran array limit "
+            f"({eph.ext_earth.shape[2]})"
+        )
+
+    # --- Earth (barycentric) ---
+    earth_pos, earth_vel = _compute_earth_ssb(kernel, tdb_jd)
+    # Earth acceleration: numerical diff of velocity at +/-1 second (matching PEP)
+    dt = 1.0 / 86400.0  # 1 second in days
+    _, vel_m1 = _compute_earth_ssb(kernel, tdb_jd - dt)
+    _, vel_p1 = _compute_earth_ssb(kernel, tdb_jd + dt)
+    # PEP does: accel = (v_plus_km_s - v_minus_km_s) * 1e3 / 2
+    # jplephem gives km/day, so convert to km/s first
+    earth_accel_m_s2 = (vel_p1 - vel_m1) / 86400.0 * 1.0e3 / 2.0
+
+    earth_pos_m = earth_pos * 1.0e3  # km -> m
+    earth_vel_m_s = earth_vel * _KM_PER_DAY_TO_M_PER_S
+
+    # --- Sun (barycentric) ---
+    sun_pos, sun_vel = kernel[0, 10].compute_and_differentiate(tdb_jd)
+    sun_pos_m = sun_pos * 1.0e3
+    sun_vel_m_s = sun_vel * _KM_PER_DAY_TO_M_PER_S
+
+    # --- Moon (barycentric) ---
+    emb_pos, emb_vel = kernel[0, 3].compute_and_differentiate(tdb_jd)
+    moon_from_emb_pos, moon_from_emb_vel = kernel[3, 301].compute_and_differentiate(tdb_jd)
+    moon_pos_m = (emb_pos + moon_from_emb_pos) * 1.0e3
+    moon_vel_m_s = (emb_vel + moon_from_emb_vel) * _KM_PER_DAY_TO_M_PER_S
+
+    # --- Geocentric Sun and Moon ---
+    sun_geo_pos = sun_pos_m - earth_pos_m
+    sun_geo_vel = sun_vel_m_s - earth_vel_m_s
+    moon_geo_pos = moon_pos_m - earth_pos_m
+    moon_geo_vel = moon_vel_m_s - earth_vel_m_s
+
+    # --- Fill Fortran arrays ---
+    # f2py exposes Fortran arrays in column-major order matching the Fortran shape.
+    # ext_earth(3,3,MAX_EPH_STEPS) -> Python shape (3,3,150)
+    for t in range(n_steps):
+        eph.ext_earth[:, 0, t] = earth_pos_m[:, t]
+        eph.ext_earth[:, 1, t] = earth_vel_m_s[:, t]
+        eph.ext_earth[:, 2, t] = earth_accel_m_s2[:, t]
+
+        eph.ext_sun[:, 0, t] = sun_geo_pos[:, t]
+        eph.ext_sun[:, 1, t] = sun_geo_vel[:, t]
+
+        eph.ext_xmoon[:, 0, t] = moon_geo_pos[:, t]
+        eph.ext_xmoon[:, 1, t] = moon_geo_vel[:, t]
+
+        eph.ext_sunb[:, 0, t] = sun_pos_m[:, t]
+        eph.ext_sunb[:, 1, t] = sun_vel_m_s[:, t]
+
+        eph.ext_moonb[:, 0, t] = moon_pos_m[:, t]
+        eph.ext_moonb[:, 1, t] = moon_vel_m_s[:, t]
+
+    # --- Planets (7 planets: Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune) ---
+    for pidx, spk_targ in enumerate(_PLANET_SPK_TARGETS):
+        p_pos, p_vel = kernel[0, spk_targ].compute_and_differentiate(tdb_jd)
+        p_pos_m = p_pos * 1.0e3
+        p_vel_m_s = p_vel * _KM_PER_DAY_TO_M_PER_S
+        for t in range(n_steps):
+            eph.ext_splanet[:, 0, pidx, t] = p_pos_m[:, t]
+            eph.ext_splanet[:, 1, pidx, t] = p_vel_m_s[:, t]
+            eph.ext_gplanet[:, 0, pidx, t] = p_pos_m[:, t] - earth_pos_m[:, t]
+            eph.ext_gplanet[:, 1, pidx, t] = p_vel_m_s[:, t] - earth_vel_m_s[:, t]
+
+    # Reset step counter for Fortran PEP to read from index 1
+    eph.eph_step_idx = 1

--- a/src/pycalc11/interface.py
+++ b/src/pycalc11/interface.py
@@ -77,6 +77,23 @@ class Calc:
         instead of by the Fortran binary file reader. This allows using
         any JPL planetary ephemeris.
         Default None (uses the built-in Fortran DE421 binary reader).
+    surface_pressure: array_like of float, optional
+        Surface atmospheric pressure at each station in mbar.
+        Must have one entry per station (matching ``station_coords``).
+        When provided, overrides the default standard-atmosphere model
+        (1013.25 mbar scaled by station altitude).
+        Default None.
+    surface_temperature: array_like of float, optional
+        Surface temperature at each station in degrees Celsius.
+        Must have one entry per station.
+        When provided, overrides the default standard-atmosphere model
+        (20 C minus 6.5 K/km lapse rate).
+        Default None.
+    surface_humidity: array_like of float, optional
+        Surface relative humidity at each station, as a fraction (0 to 1).
+        Must have one entry per station.
+        When provided, overrides the default value of 0.5 (50%).
+        Default None.
 
     Notes
     -----
@@ -127,6 +144,9 @@ class Calc:
         check_sites=True,
         debug_flags=None,
         ephemeris=None,
+        surface_pressure=None,
+        surface_temperature=None,
+        surface_humidity=None,
     ):
         # Setting defaults
         self._reset()  # Clear if there's another instance.
@@ -208,6 +228,11 @@ class Calc:
         self._spk_kernel = None
         if ephemeris is not None:
             self._setup_ephemeris(ephemeris)
+
+        # Surface meteorology
+        self.surface_pressure = surface_pressure
+        self.surface_temperature = surface_temperature
+        self.surface_humidity = surface_humidity
 
         # Ensure the DE421 Fortran binary path is set before dinitl reads it.
         # This is needed even with an external ephemeris, since dinitl may
@@ -302,6 +327,13 @@ class Calc:
         calc.srcmod.numstr = 0
         calc.units.ipoint = 40  # Reset units counter
         calc.units.iutot = 3
+
+        # Clear external ephemeris and met data
+        calc.ephcom.use_ext_ephem = False
+        calc.metmod.use_ext_met = False
+        calc.metmod.ext_pressure[:] = 0.0
+        calc.metmod.ext_temperature[:] = 0.0
+        calc.metmod.ext_humidity[:] = 0.0
 
         for key, part in calc.__dict__.items():
             # Select only common blocks
@@ -479,6 +511,80 @@ class Calc:
             raise ValueError("wet_atm must be a boolean type.")
         calc.contrl.atmwt[()] = b"Add-wet   " if value else b""
         self._rerun = True
+
+    @property
+    def surface_pressure(self):
+        """Surface pressure at each station in mbar, or None for default model."""
+        if not calc.metmod.use_ext_met:
+            return None
+        return calc.metmod.ext_pressure[1 : self.nants + 1].copy()
+
+    @surface_pressure.setter
+    def surface_pressure(self, value):
+        if value is None:
+            self._update_ext_met()
+            return
+        value = np.atleast_1d(np.asarray(value, dtype=np.float64))
+        if value.shape != (self.nants,):
+            raise ValueError(
+                f"surface_pressure must have shape ({self.nants},), got {value.shape}"
+            )
+        if np.any(value <= 0):
+            raise ValueError("surface_pressure values must be positive (mbar).")
+        calc.metmod.ext_pressure[1 : self.nants + 1] = value
+        self._update_ext_met()
+        self._rerun = True
+
+    @property
+    def surface_temperature(self):
+        """Surface temperature at each station in degrees Celsius, or None for default model."""
+        if not calc.metmod.use_ext_met:
+            return None
+        return calc.metmod.ext_temperature[1 : self.nants + 1].copy()
+
+    @surface_temperature.setter
+    def surface_temperature(self, value):
+        if value is None:
+            self._update_ext_met()
+            return
+        value = np.atleast_1d(np.asarray(value, dtype=np.float64))
+        if value.shape != (self.nants,):
+            raise ValueError(
+                f"surface_temperature must have shape ({self.nants},), got {value.shape}"
+            )
+        calc.metmod.ext_temperature[1 : self.nants + 1] = value
+        self._update_ext_met()
+        self._rerun = True
+
+    @property
+    def surface_humidity(self):
+        """Surface relative humidity at each station (0 to 1), or None for default model."""
+        if not calc.metmod.use_ext_met:
+            return None
+        return calc.metmod.ext_humidity[1 : self.nants + 1].copy()
+
+    @surface_humidity.setter
+    def surface_humidity(self, value):
+        if value is None:
+            self._update_ext_met()
+            return
+        value = np.atleast_1d(np.asarray(value, dtype=np.float64))
+        if value.shape != (self.nants,):
+            raise ValueError(
+                f"surface_humidity must have shape ({self.nants},), got {value.shape}"
+            )
+        if np.any((value < 0) | (value > 1)):
+            raise ValueError("surface_humidity values must be between 0 and 1.")
+        calc.metmod.ext_humidity[1 : self.nants + 1] = value
+        self._update_ext_met()
+        self._rerun = True
+
+    def _update_ext_met(self):
+        """Enable or disable external met data based on which fields are set."""
+        has_p = np.any(calc.metmod.ext_pressure[1 : self.nants + 1] != 0)
+        has_t = np.any(calc.metmod.ext_temperature[1 : self.nants + 1] != 0)
+        has_h = np.any(calc.metmod.ext_humidity[1 : self.nants + 1] != 0)
+        calc.metmod.use_ext_met = has_p or has_t or has_h
 
     @property
     def uvw_mode(self):
@@ -965,7 +1071,7 @@ def is_initialized(cb, item):
     """
     return (
         cb == "cmath"
-        or cb in ("outputs", "srcmod", "datafiles", "ephcom")  # Modules
+        or cb in ("outputs", "srcmod", "datafiles", "ephcom", "metmod")  # Modules
         or cb in "units"  # File unit vars
         or cb == "cticm"
         and item != "a1tai"  # cctiu.f

--- a/src/pycalc11/interface.py
+++ b/src/pycalc11/interface.py
@@ -1,5 +1,6 @@
 """Classes to interface with compiled Fortran code."""
 
+import os
 import numpy as np
 import warnings
 from functools import partial
@@ -67,6 +68,15 @@ class Calc:
         Sets specific functions to print debug information.
         See DebugFlags class for list of flags
         Default None
+    ephemeris: str, optional
+        JPL ephemeris to use for solar system body positions. Can be:
+        - A path to an SPK (.bsp) file
+        - A name like 'de421', 'de430', 'de440', 'de440s', 'de441'
+          (will be downloaded and cached automatically)
+        When set, ephemeris positions are computed in Python via jplephem
+        instead of by the Fortran binary file reader. This allows using
+        any JPL planetary ephemeris.
+        Default None (uses the built-in Fortran DE421 binary reader).
 
     Notes
     -----
@@ -110,6 +120,7 @@ class Calc:
         d_interval=24,
         check_sites=True,
         debug_flags=None,
+        ephemeris=None,
     ):
         # Setting defaults
         self._reset()  # Clear if there's another instance.
@@ -178,6 +189,11 @@ class Calc:
         # Add geocenter station
         self._add_geocenter()
 
+        # Set up ephemeris provider
+        self._spk_kernel = None
+        if ephemeris is not None:
+            self._setup_ephemeris(ephemeris)
+
         calc.dinitl(1)
 
     def parse_calcfile(self, calcfile):
@@ -206,6 +222,11 @@ class Calc:
         self.alloc_out_arrays()
         e2m = calc.contrl.epoch2m - 1
         for ii in range(calc.calc_input.intrvls2min):
+            if self._spk_kernel is not None:
+                from .ephemeris import fill_ephem_arrays
+
+                tdb_jds = self._compute_epoch_tdb(ii)
+                fill_ephem_arrays(self._spk_kernel, tdb_jds, calc)
             calc.adrivr(1, ii + 1)
             slc = np.s_[ii * e2m : ii * e2m + e2m, :, :, :]
             self._delay[slc] = calc.outputs.delay_f[:-1, :, :, 1:]  # Skip pointing source
@@ -280,6 +301,44 @@ class Calc:
         calc.calc_input.axis[0] = "AZEL"
         calc.sitcm.sitaxo[0] = 0.0  # Axis offset
         calc.sitcm.sitxyz[:, 0] = [0, 0, 0]
+
+    def _setup_ephemeris(self, ephemeris):
+        """Configure external ephemeris via jplephem SPK kernel.
+
+        Parameters
+        ----------
+        ephemeris : str
+            Either a path to an SPK file, or a name like 'de440s' to download.
+        """
+        from jplephem.spk import SPK
+        from . import get_spk
+
+        if os.path.isfile(ephemeris):
+            spk_path = ephemeris
+        else:
+            spk_path = get_spk(ephemeris)
+        self._spk_kernel = SPK.open(spk_path)
+        calc.ephcom.use_ext_ephem = True
+
+    def _compute_epoch_tdb(self, epoch_index):
+        """Compute TDB Julian dates for all steps in a 2-minute epoch.
+
+        Parameters
+        ----------
+        epoch_index : int
+            Zero-based index of the 2-minute epoch.
+
+        Returns
+        -------
+        numpy.ndarray
+            TDB Julian dates for each time step.
+        """
+        e2m = int(calc.contrl.epoch2m)
+        d_interval = float(calc.contrl.d_interval)
+        epoch_start = self._start_time + TimeDelta(epoch_index * 120, format="sec")
+        step_offsets = np.arange(e2m) * d_interval
+        times = epoch_start + TimeDelta(step_offsets, format="sec")
+        return times.tdb.jd
 
     def set_scan(self, time, duration_min):
         """
@@ -885,7 +944,7 @@ def is_initialized(cb, item):
     """
     return (
         cb == "cmath"
-        or cb in ("outputs", "srcmod", "datafiles")  # Modules
+        or cb in ("outputs", "srcmod", "datafiles", "ephcom")  # Modules
         or cb in "units"  # File unit vars
         or cb == "cticm"
         and item != "a1tai"  # cctiu.f

--- a/src/pycalc11/interface.py
+++ b/src/pycalc11/interface.py
@@ -70,13 +70,21 @@ class Calc:
         Default None
     ephemeris: str, optional
         JPL ephemeris to use for solar system body positions. Can be:
-        - A path to an SPK (.bsp) file
         - A name like 'de421', 'de430', 'de440', 'de440s', 'de441'
-          (will be downloaded and cached automatically)
-        When set, ephemeris positions are computed in Python via jplephem
-        instead of by the Fortran binary file reader. This allows using
-        any JPL planetary ephemeris.
-        Default None (uses the built-in Fortran DE421 binary reader).
+          (an SPK kernel will be downloaded and cached automatically)
+        - A path to an SPK (.bsp) file
+        - The string 'legacy' (or 'fortran'), to use the built-in Fortran
+          DE421 binary reader.
+        For a name or path, ephemeris positions are computed in Python via
+        jplephem, which allows using any JPL planetary ephemeris.
+        Default None, which uses the JPL SPK kernel named by
+        ``pycalc11.DEFAULT_EPHEMERIS`` (currently 'de440s').
+
+        .. note::
+            'legacy' mode downloads the DE421 binary from the difx GitHub
+            mirror and pins results to the superseded DE421 ephemeris. It is
+            retained mainly for reproducing older results. Prefer the default
+            (or an explicit 'de421') for new work.
     surface_pressure: array_like of float, optional
         Surface atmospheric pressure at each station in mbar.
         Must have one entry per station (matching ``station_coords``).
@@ -224,22 +232,19 @@ class Calc:
         # Add geocenter station
         self._add_geocenter()
 
-        # Set up ephemeris provider
+        # Set up ephemeris provider. Defaults to the package default JPL SPK
+        # kernel; pass ephemeris="legacy" for the Fortran DE421 binary reader.
         self._spk_kernel = None
-        if ephemeris is not None:
-            self._setup_ephemeris(ephemeris)
+        if ephemeris is None:
+            from . import DEFAULT_EPHEMERIS
+
+            ephemeris = DEFAULT_EPHEMERIS
+        self._setup_ephemeris(ephemeris)
 
         # Surface meteorology
         self.surface_pressure = surface_pressure
         self.surface_temperature = surface_temperature
         self.surface_humidity = surface_humidity
-
-        # Ensure the DE421 Fortran binary path is set before dinitl reads it.
-        # This is needed even with an external ephemeris, since dinitl may
-        # reference the path during initialization.
-        from . import _ensure_de421
-
-        _ensure_de421()
 
         calc.dinitl(1)
 
@@ -357,13 +362,29 @@ class Calc:
         calc.sitcm.sitxyz[:, 0] = [0, 0, 0]
 
     def _setup_ephemeris(self, ephemeris):
-        """Configure external ephemeris via jplephem SPK kernel.
+        """Configure the ephemeris provider.
 
         Parameters
         ----------
         ephemeris : str
-            Either a path to an SPK file, or a name like 'de440s' to download.
+            One of:
+            - 'legacy' or 'fortran': use the built-in Fortran DE421 binary
+              reader (downloads the legacy DE421 binary on first use).
+            - a path to an SPK (.bsp) file.
+            - a name like 'de440s' to download an SPK kernel.
+            The latter two compute ephemeris positions in Python via jplephem.
         """
+        if isinstance(ephemeris, str) and ephemeris.lower() in ("legacy", "fortran"):
+            # Legacy Fortran DE421 binary reader. The binary is opened lazily
+            # by the Fortran PEP/STATE routines during run_driver, but ensure
+            # the path is set here so it is ready by then.
+            from . import _ensure_de421
+
+            self._spk_kernel = None
+            calc.ephcom.use_ext_ephem = False
+            _ensure_de421()
+            return
+
         from jplephem.spk import SPK
         from . import get_spk
 
@@ -389,7 +410,13 @@ class Calc:
         """
         e2m = int(calc.contrl.epoch2m)
         d_interval = float(calc.contrl.d_interval)
-        epoch_start = self._start_time + TimeDelta(epoch_index * 120, format="sec")
+        if self._start_time is not None:
+            scan_start = self._start_time
+        else:
+            # Scan configured via a .calc file: recover the start time from the
+            # Fortran common block, where dscan stored it as a UTC Julian Date.
+            scan_start = Time(float(calc.ut1cm.xintv[0]), format="jd", scale="utc")
+        epoch_start = scan_start + TimeDelta(epoch_index * 120, format="sec")
         step_offsets = np.arange(e2m) * d_interval
         times = epoch_start + TimeDelta(step_offsets, format="sec")
         return times.tdb.jd

--- a/src/pycalc11/interface.py
+++ b/src/pycalc11/interface.py
@@ -238,6 +238,7 @@ class Calc:
         # This is needed even with an external ephemeris, since dinitl may
         # reference the path during initialization.
         from . import _ensure_de421
+
         _ensure_de421()
 
         calc.dinitl(1)
@@ -526,9 +527,7 @@ class Calc:
             return
         value = np.atleast_1d(np.asarray(value, dtype=np.float64))
         if value.shape != (self.nants,):
-            raise ValueError(
-                f"surface_pressure must have shape ({self.nants},), got {value.shape}"
-            )
+            raise ValueError(f"surface_pressure must have shape ({self.nants},), got {value.shape}")
         if np.any(value <= 0):
             raise ValueError("surface_pressure values must be positive (mbar).")
         calc.metmod.ext_pressure[1 : self.nants + 1] = value
@@ -570,9 +569,7 @@ class Calc:
             return
         value = np.atleast_1d(np.asarray(value, dtype=np.float64))
         if value.shape != (self.nants,):
-            raise ValueError(
-                f"surface_humidity must have shape ({self.nants},), got {value.shape}"
-            )
+            raise ValueError(f"surface_humidity must have shape ({self.nants},), got {value.shape}")
         if np.any((value < 0) | (value > 1)):
             raise ValueError("surface_humidity values must be between 0 and 1.")
         calc.metmod.ext_humidity[1 : self.nants + 1] = value

--- a/src/pycalc11/interface.py
+++ b/src/pycalc11/interface.py
@@ -83,6 +83,12 @@ class Calc:
     Keyword arguments supersede options in a loaded .calc file. For instance,
     if a set of sources is provided via the `source_names` and `source_coords` options,
     then the stations used in CALC will match those and not the ones in the provided .calc file.
+
+    .. warning::
+        The underlying Fortran code uses global state (common blocks). Only one
+        ``Calc`` instance may be executing ``run_driver`` at a time. Running
+        multiple instances concurrently (e.g., via threads) will produce
+        incorrect results.
     """
 
     _rerun = True  # Rerun driver before accessing results
@@ -145,6 +151,15 @@ class Calc:
             120.0001 / calc.contrl.d_interval
         ) + 1  # Number of steps in 2 min epoch
 
+        max_steps = int(calc.ephcom.ext_earth.shape[2])
+        n_steps = int(calc.contrl.epoch2m)
+        if n_steps > max_steps:
+            raise ValueError(
+                f"d_interval={d_interval} s produces {n_steps} steps per 2-minute "
+                f"epoch, exceeding the Fortran limit of {max_steps}. "
+                f"Increase d_interval to at least {120.0 / (max_steps - 1):.1f} s."
+            )
+
         # Set debug flags, if any
         # Note -- some can be quite noisy. TODO Clean up Fortran side of debugging info
         self.debug_flags = DebugFlags(debug_flags)
@@ -193,6 +208,12 @@ class Calc:
         self._spk_kernel = None
         if ephemeris is not None:
             self._setup_ephemeris(ephemeris)
+
+        # Ensure the DE421 Fortran binary path is set before dinitl reads it.
+        # This is needed even with an external ephemeris, since dinitl may
+        # reference the path during initialization.
+        from . import _ensure_de421
+        _ensure_de421()
 
         calc.dinitl(1)
 

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -142,6 +142,10 @@ def run_calc_2x(
 
 def test_reset(params_vlbi):
     #   Reset works properly
+    # Ensure lazy-loaded DE421 path is set before capturing baseline state,
+    # since it is set once on first Calc creation and never cleared.
+    from pycalc11 import _ensure_de421
+    _ensure_de421()
     stat0 = get_mod_state(calc)
     ci = Calc(**params_vlbi)
     assert not compare_dicts(stat0, get_mod_state(calc), quiet=True)

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -145,6 +145,7 @@ def test_reset(params_vlbi):
     # Ensure lazy-loaded DE421 path is set before capturing baseline state,
     # since it is set once on first Calc creation and never cleared.
     from pycalc11 import _ensure_de421
+
     _ensure_de421()
     stat0 = get_mod_state(calc)
     ci = Calc(**params_vlbi)
@@ -573,17 +574,17 @@ def _make_simple_calc(**extra_kwargs):
         ac.EarthLocation.from_geodetic(lon=-80.0, lat=26.0, height=50),
     ]
     srcs = ac.SkyCoord(ra=[45, 180], dec=[30, -20], unit="deg", frame="icrs")
-    kwargs = dict(
-        station_names=["STA1", "STA2"],
-        station_coords=locs,
-        source_coords=srcs,
-        start_time=time,
-        duration_min=4,
-        base_mode="geocenter",
-        dry_atm=False,
-        wet_atm=False,
-        check_sites=False,
-    )
+    kwargs = {
+        "station_names": ["STA1", "STA2"],
+        "station_coords": locs,
+        "source_coords": srcs,
+        "start_time": time,
+        "duration_min": 4,
+        "base_mode": "geocenter",
+        "dry_atm": False,
+        "wet_atm": False,
+        "check_sites": False,
+    }
     kwargs.update(extra_kwargs)
     ci = Calc(**kwargs)
     ci.run_driver()
@@ -670,20 +671,20 @@ def test_surface_met_reset_clears_state():
 
 def test_surface_met_validation():
     """Invalid surface met inputs should raise errors."""
-    base = dict(
-        station_names=["STA1", "STA2"],
-        station_coords=[
+    base = {
+        "station_names": ["STA1", "STA2"],
+        "station_coords": [
             ac.EarthLocation.from_geodetic(lon=-118.0, lat=34.0, height=100),
             ac.EarthLocation.from_geodetic(lon=-80.0, lat=26.0, height=50),
         ],
-        source_coords=ac.SkyCoord(ra=[45, 180], dec=[30, -20], unit="deg", frame="icrs"),
-        start_time=Time("2020-01-01T00:00:00", scale="utc"),
-        duration_min=4,
-        base_mode="geocenter",
-        dry_atm=False,
-        wet_atm=False,
-        check_sites=False,
-    )
+        "source_coords": ac.SkyCoord(ra=[45, 180], dec=[30, -20], unit="deg", frame="icrs"),
+        "start_time": Time("2020-01-01T00:00:00", scale="utc"),
+        "duration_min": 4,
+        "base_mode": "geocenter",
+        "dry_atm": False,
+        "wet_atm": False,
+        "check_sites": False,
+    }
     # Wrong length
     with pytest.raises(ValueError, match="shape"):
         Calc(**base, surface_pressure=[1013.0])

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -554,3 +554,53 @@ def test_uvw(uvw_mode, tol, cent):
     bls_py = uvw_py[:, :2] - uvw_py[:, [2]]
     print(uvw_mode, cent.lat, np.max(np.abs(bls_ap - bls_py).to_value("cm")))
     assert_quantity_allclose(bls_ap, bls_py, atol=tol)
+
+
+# -----------------------------------
+# External ephemeris tests
+# -----------------------------------
+
+
+def _make_simple_calc(**extra_kwargs):
+    """Helper to create a Calc instance with a small, fast configuration."""
+    time = Time("2020-01-01T00:00:00", scale="utc")
+    locs = [
+        ac.EarthLocation.from_geodetic(lon=-118.0, lat=34.0, height=100),
+        ac.EarthLocation.from_geodetic(lon=-80.0, lat=26.0, height=50),
+    ]
+    srcs = ac.SkyCoord(ra=[45, 180], dec=[30, -20], unit="deg", frame="icrs")
+    kwargs = dict(
+        station_names=["STA1", "STA2"],
+        station_coords=locs,
+        source_coords=srcs,
+        start_time=time,
+        duration_min=4,
+        base_mode="geocenter",
+        dry_atm=False,
+        wet_atm=False,
+        check_sites=False,
+    )
+    kwargs.update(extra_kwargs)
+    ci = Calc(**kwargs)
+    ci.run_driver()
+    return ci
+
+
+def test_jplephem_de421_matches_fortran():
+    """DE421 via jplephem should match the Fortran binary reader to ~10 ps."""
+    c_fortran = _make_simple_calc()
+    c_jplephem = _make_simple_calc(ephemeris="de421")
+
+    diff = np.abs(c_fortran.delay.to_value("s") - c_jplephem.delay.to_value("s"))
+    # Allow up to 10 ps difference (from TDB computation differences)
+    assert np.all(diff < 10e-12), f"Max diff = {np.max(diff) * 1e12:.2f} ps"
+
+
+def test_de440s_close_to_de421():
+    """DE440s and DE421 should agree to within ~1 ns for a modern epoch."""
+    c_de421 = _make_simple_calc(ephemeris="de421")
+    c_de440s = _make_simple_calc(ephemeris="de440s")
+
+    diff = np.abs(c_de421.delay.to_value("s") - c_de440s.delay.to_value("s"))
+    # Ephemeris versions differ by tens of ps; allow up to 1 ns
+    assert np.all(diff < 1e-9), f"Max diff = {np.max(diff) * 1e12:.2f} ps"

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -142,8 +142,10 @@ def run_calc_2x(
 
 def test_reset(params_vlbi):
     #   Reset works properly
-    # Ensure lazy-loaded DE421 path is set before capturing baseline state,
-    # since it is set once on first Calc creation and never cleared.
+    # Ensure the legacy DE421 binary path is set before capturing the baseline
+    # state. _reset() does not clear it (datafiles is treated as initialized),
+    # so pinning it here keeps the baseline consistent regardless of whether a
+    # legacy-ephemeris test ran earlier in the session.
     from pycalc11 import _ensure_de421
 
     _ensure_de421()
@@ -367,7 +369,11 @@ def test_compare_to_difxcalc(params_vlbi, tmpdir):
     params_vlbi["duration_min"] = 20
 
     quantities = ["delay", "delay_rate", "partials", "times", "uvw"]
-    ci = Calc(**params_vlbi, base_mode="geocenter", dry_atm=False, wet_atm=False)
+    # Use the legacy Fortran DE421 reader so the ephemeris matches the
+    # separately-installed difxcalc binary (which also uses DE421).
+    ci = Calc(
+        **params_vlbi, base_mode="geocenter", dry_atm=False, wet_atm=False, ephemeris="legacy"
+    )
     ci.run_driver()
     quants1 = {q: getattr(ci, q).copy() for q in quantities}
 
@@ -591,12 +597,28 @@ def _make_simple_calc(**extra_kwargs):
     return ci
 
 
-def test_jplephem_de421_matches_fortran():
-    """DE421 via jplephem should match the Fortran binary reader to ~10 ps."""
-    c_fortran = _make_simple_calc()
+def test_default_ephemeris_is_jpl_spk():
+    """With no ephemeris specified, the default is a JPL SPK kernel (not legacy)."""
+    from pycalc11 import DEFAULT_EPHEMERIS
+
+    assert DEFAULT_EPHEMERIS == "de440s"
+    c_default = _make_simple_calc()
+    # Default path loads an SPK kernel and enables the external-ephemeris flag.
+    assert c_default._spk_kernel is not None
+    assert bool(calc.ephcom.use_ext_ephem)
+
+
+def test_legacy_matches_jplephem_de421():
+    """The legacy Fortran DE421 reader should match JPL SPK DE421 to ~10 ps.
+
+    This confirms that the legacy binary ephemeris and the jplephem-based
+    DE421 SPK kernel produce equivalent delays, so switching the default to
+    the JPL path preserves numerical agreement with the old default.
+    """
+    c_legacy = _make_simple_calc(ephemeris="legacy")
     c_jplephem = _make_simple_calc(ephemeris="de421")
 
-    diff = np.abs(c_fortran.delay.to_value("s") - c_jplephem.delay.to_value("s"))
+    diff = np.abs(c_legacy.delay.to_value("s") - c_jplephem.delay.to_value("s"))
     # Allow up to 10 ps difference (from TDB computation differences)
     assert np.all(diff < 10e-12), f"Max diff = {np.max(diff) * 1e12:.2f} ps"
 

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -608,3 +608,106 @@ def test_de440s_close_to_de421():
     diff = np.abs(c_de421.delay.to_value("s") - c_de440s.delay.to_value("s"))
     # Ephemeris versions differ by tens of ps; allow up to 1 ns
     assert np.all(diff < 1e-9), f"Max diff = {np.max(diff) * 1e12:.2f} ps"
+
+
+# -----------------------------------
+# Surface meteorology tests
+# -----------------------------------
+
+
+def test_surface_met_changes_delay():
+    """Supplying surface met data should produce different delays than the default model."""
+    c_default = _make_simple_calc(dry_atm=True, wet_atm=True)
+    c_met = _make_simple_calc(
+        dry_atm=True,
+        wet_atm=True,
+        surface_pressure=[950.0, 1020.0],
+        surface_temperature=[30.0, 15.0],
+        surface_humidity=[0.2, 0.8],
+    )
+
+    d_default = c_default.delay.to_value("s")
+    d_met = c_met.delay.to_value("s")
+
+    diff = np.abs(d_default - d_met)
+    # Met data should change delays by at least ~0.1 ns
+    assert np.max(diff) > 1e-10, f"Max diff = {np.max(diff):.3e} s; expected > 0.1 ns"
+    # But not by more than ~100 ns (sanity check)
+    assert np.max(diff) < 1e-7, f"Max diff = {np.max(diff):.3e} s; unreasonably large"
+
+
+def test_surface_met_default_is_none():
+    """Without surface met data, properties should return None."""
+    ci = _make_simple_calc()
+    assert ci.surface_pressure is None
+    assert ci.surface_temperature is None
+    assert ci.surface_humidity is None
+
+
+def test_surface_met_properties_roundtrip():
+    """Surface met properties should reflect what was set."""
+    ci = _make_simple_calc(
+        surface_pressure=[1013.0, 1013.0],
+        surface_temperature=[20.0, 20.0],
+        surface_humidity=[0.5, 0.5],
+    )
+    # Properties read back correctly before another Calc resets global state
+    assert_allclose(ci.surface_pressure, [1013.0, 1013.0])
+    assert_allclose(ci.surface_temperature, [20.0, 20.0])
+    assert_allclose(ci.surface_humidity, [0.5, 0.5])
+
+
+def test_surface_met_reset_clears_state():
+    """Creating a new Calc without met data should clear the met state."""
+    _make_simple_calc(
+        surface_pressure=[950.0, 1020.0],
+        surface_temperature=[30.0, 15.0],
+        surface_humidity=[0.2, 0.8],
+    )
+    ci = _make_simple_calc()
+    assert ci.surface_pressure is None
+
+
+def test_surface_met_validation():
+    """Invalid surface met inputs should raise errors."""
+    base = dict(
+        station_names=["STA1", "STA2"],
+        station_coords=[
+            ac.EarthLocation.from_geodetic(lon=-118.0, lat=34.0, height=100),
+            ac.EarthLocation.from_geodetic(lon=-80.0, lat=26.0, height=50),
+        ],
+        source_coords=ac.SkyCoord(ra=[45, 180], dec=[30, -20], unit="deg", frame="icrs"),
+        start_time=Time("2020-01-01T00:00:00", scale="utc"),
+        duration_min=4,
+        base_mode="geocenter",
+        dry_atm=False,
+        wet_atm=False,
+        check_sites=False,
+    )
+    # Wrong length
+    with pytest.raises(ValueError, match="shape"):
+        Calc(**base, surface_pressure=[1013.0])
+    # Negative pressure
+    with pytest.raises(ValueError, match="positive"):
+        Calc(**base, surface_pressure=[-1.0, 1013.0])
+    # Humidity out of range
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        Calc(**base, surface_humidity=[0.5, 1.5])
+
+
+def test_surface_met_only_affects_atm():
+    """With atm disabled, surface met data should not change delays."""
+    c_noatm = _make_simple_calc(dry_atm=False, wet_atm=False)
+    c_noatm_met = _make_simple_calc(
+        dry_atm=False,
+        wet_atm=False,
+        surface_pressure=[950.0, 1020.0],
+        surface_temperature=[30.0, 15.0],
+        surface_humidity=[0.2, 0.8],
+    )
+
+    d1 = c_noatm.delay.to_value("s")
+    d2 = c_noatm_met.delay.to_value("s")
+
+    # With atmosphere disabled, met data should have no effect
+    assert_allclose(d1, d2, atol=1e-15)


### PR DESCRIPTION
Adds support for other JPL ephemerides files and allows the user to set temperature, pressure, and humidity at each site

difxcalc11 was written to use DE421 as stored in specific binary files. I haven't been able to find these ephemeris files anywhere but in the difxcalc11 repository, and there are more recent ephemeris data files (DE430, DE440, etc.). This change maintains the original DE421 as the default, but allows the user to select other ephemerides, which are loaded on the python side. This should be more future-proof.

The atmospheric corrections assume default values for temperature, pressure, and humidity. Variation in these conditions can lead to errors up to ~ 10 ns. CALC11 already includes these as settable parameters, and this PR opens that up to the Python side.