### PR TITLE
change url for DE421 ephemeris

### DIFF
--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
          fetch-depth: 1
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Setup Environment

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Install directly from the repository with pip::
 The source code for CALC is in the repository and will be built and added as an
 extension to the pycalc11 module.
 
-On a first run, `pycalc11` will download and cache the JPL DE421 ephemeris file from ATNF. This can take around 30s.
+On a first run, `pycalc11` will download and cache the JPL DE421 ephemeris file from a GitHub repository for difx. This can take around 30s.
 
 NOTE: Tests of the MacOS installation are currently failing.
      This seems to be due to some issue with gcc on the latest Mac versions. If you have trouble installing on a Mac, it's an issue with the build environment. See https://github.com/aelanman/pycalc11/issues/18

--- a/ci/cache_data.py
+++ b/ci/cache_data.py
@@ -20,7 +20,7 @@ Time.now().ut1
 
 if sys.argv[1] == "save":
     if not os.path.exists(cache_file):
-        de421_url = f"https://svn.atnf.csiro.au/difx/applications/difxcalc11/trunk/data/DE421_{sys.byteorder}_Endian"
+        de421_url = f"https://github.com/difx/difx/raw/refs/heads/main/applications/difxcalc11/data/DE421_{sys.byteorder}_Endian"
         de421_path = download_file(de421_url, cache=True)
         urls = get_cached_urls()
         export_download_cache(cache_file, urls=urls, overwrite=True)

--- a/src/pycalc11/__init__.py
+++ b/src/pycalc11/__init__.py
@@ -8,7 +8,7 @@ from . import runner
 
 
 # Get JPL ephemeris data
-de421_url = f"https://svn.atnf.csiro.au/difx/applications/difxcalc11/trunk/data/DE421_{sys.byteorder}_Endian"
+de421_url = f"https://github.com/difx/difx/raw/refs/heads/main/applications/difxcalc11/data/DE421_{sys.byteorder}_Endian"
 de421_path = download_file(de421_url, cache=True)
 calc11.datafiles.jpl_de421 = de421_path.ljust(128)
 


### PR DESCRIPTION
The ATNF subversion repo is no longer available. Changes to download from the GitHub clone.